### PR TITLE
add rubocop to rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,8 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+unless Rails.env.production?
+  task(:default).clear
+  task default: %i[rubocop spec]
+end


### PR DESCRIPTION
Running bin/rake now runs rubocop and the specs. 
As we run rubocop on Circle CI this can help to prevent sending up jobs that fail at the first hurdle.
Also keeps it in line with our other repos.