### PR TITLE
Ap 2451 add default cost limitations

### DIFF
--- a/app/models/default_cost_limitation.rb
+++ b/app/models/default_cost_limitation.rb
@@ -1,3 +1,12 @@
 class DefaultCostLimitation < ApplicationRecord
   belongs_to :proceeding_type
+
+  enum cost_type: {
+    delegated_functions: 'delegated_functions'.freeze,
+    substantive: 'substantive'.freeze
+  }
+
+  def self.for_date(date)
+    where('start_date <= ?', date).order(start_date: :desc).first
+  end
 end

--- a/app/models/default_cost_limitation.rb
+++ b/app/models/default_cost_limitation.rb
@@ -1,0 +1,3 @@
+class DefaultCostLimitation < ApplicationRecord
+  belongs_to :proceeding_type
+end

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -16,4 +16,12 @@ class ProceedingType < ApplicationRecord
            class_name: 'ProceedingTask'
 
   has_many :default_cost_limitations, dependent: :destroy
+
+  def default_cost_limitation_delegated_functions
+    default_cost_limitations.delegated_functions.for_date(Date.current).value
+  end
+
+  def default_cost_limitation_substantive
+    default_cost_limitations.substantive.for_date(Date.current).value
+  end
 end

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -14,6 +14,6 @@ class ProceedingType < ApplicationRecord
            through: :proceeding_type_merits_tasks,
            source: :merits_task,
            class_name: 'ProceedingTask'
-  
+
   has_many :default_cost_limitations, dependent: :destroy
 end

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -14,4 +14,6 @@ class ProceedingType < ApplicationRecord
            through: :proceeding_type_merits_tasks,
            source: :merits_task,
            class_name: 'ProceedingTask'
+  
+  has_many :default_cost_limitations, dependent: :destroy
 end

--- a/db/migrate/20210930074336_create_default_cost_limitations.rb
+++ b/db/migrate/20210930074336_create_default_cost_limitations.rb
@@ -1,0 +1,12 @@
+class CreateDefaultCostLimitations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :default_cost_limitations, id: :uuid do |t|
+      t.belongs_to :proceeding_type, foreign_key: true, null: false, type: :uuid
+      t.date :start_date, null: false
+      t.string :cost_type, null: false
+      t.decimal :value, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/populators/proceeding_type_populator.rb
+++ b/db/populators/proceeding_type_populator.rb
@@ -7,6 +7,7 @@ class ProceedingTypePopulator
 
   def call
     seed_data.each { |seed_row| populate(seed_row) }
+    populate_default_cost_limitations
   end
 
   private
@@ -33,5 +34,23 @@ class ProceedingTypePopulator
 
   def seed_data
     @seed_data ||= YAML.load_file(DATA_FILE)
+  end
+
+  def populate_default_cost_limitations
+    pts = ProceedingType.all
+    pts.each { |pt| add_cost_limitations(pt) }
+  end
+
+  def add_cost_limitations(proceeding_type)
+    find_or_create_dcl(proceeding_type: proceeding_type, cost_type: 'substantive', start_date: Date.parse('1970-01-01'), value: 25_000.0)
+    find_or_create_dcl(proceeding_type: proceeding_type, cost_type: 'delegated_functions', start_date: Date.parse('1970-01-01'), value: 1_350.0)
+    find_or_create_dcl(proceeding_type: proceeding_type, cost_type: 'delegated_functions', start_date: Date.parse('2021-09-13'), value: 2_250.0)
+  end
+
+  def find_or_create_dcl(proceeding_type:, cost_type:, start_date:, value:)
+    dcl = DefaultCostLimitation.find_by(proceeding_type: proceeding_type, cost_type: cost_type, start_date: start_date, value: value)
+    return if dcl.present?
+
+    DefaultCostLimitation.create!(proceeding_type: proceeding_type, cost_type: cost_type, start_date: start_date, value: value)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_05_101611) do
+ActiveRecord::Schema.define(version: 2021_09_30_074336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "default_cost_limitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "proceeding_type_id", null: false
+    t.date "start_date", null: false
+    t.string "cost_type", null: false
+    t.decimal "value", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["proceeding_type_id"], name: "index_default_cost_limitations_on_proceeding_type_id"
+  end
 
   create_table "matter_types", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
@@ -70,4 +80,5 @@ ActiveRecord::Schema.define(version: 2021_04_05_101611) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "default_cost_limitations", "proceeding_types"
 end

--- a/spec/models/default_cost_limitation_spec.rb
+++ b/spec/models/default_cost_limitation_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe DefaultCostLimitation do
+  before { seed_live_data }
+
+  describe '#cost_type' do
+    it 'does not allow invalid cost types' do
+      expect {
+        DefaultCostLimitation.create!(proceeding_type: ProceedingType.first, cost_type: 'xxxx', start_date: 1.month.ago, value: 55)
+      }.to raise_error ArgumentError, "'xxxx' is not a valid cost_type"
+    end
+  end
+
+  describe '.for_date(date)' do
+    context 'before change date' do
+      let(:date) { Date.parse('2021-09-12') }
+
+      it 'returns the old value' do
+        dcl = DefaultCostLimitation.delegated_functions.for_date(date)
+        expect(dcl.value).to eq 1350
+      end
+    end
+
+    context 'on change date' do
+      let(:date) { Date.parse('2021-09-13') }
+      it 'returns the old value' do
+        dcl = DefaultCostLimitation.delegated_functions.for_date(date)
+        expect(dcl.value).to eq 2250
+      end
+    end
+
+    context 'on change date' do
+      let(:date) { Date.parse('2021-09-19') }
+      it 'returns the old value' do
+        dcl = DefaultCostLimitation.delegated_functions.for_date(date)
+        expect(dcl.value).to eq 2250
+      end
+    end
+  end
+end

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProceedingType do
+  include ActiveSupport::Testing::TimeHelpers
   before { seed_live_data }
 
   describe '#matter_type' do
@@ -29,6 +30,34 @@ RSpec.describe ProceedingType do
     it 'returns ordered list of proceeding_level tasks only' do
       rec = ProceedingType.find_by(ccms_code: 'DA003')
       expect(rec.proceeding_tasks.map(&:name)).to eq %w[chances_of_success]
+    end
+  end
+
+  context 'cost limitations' do
+    let(:pt) { ProceedingType.first }
+
+    around do |example|
+      travel_to run_date
+      example.run
+      travel_back
+    end
+
+    describe 'before the change' do
+      let(:run_date) { Date.parse('2021-09-11') }
+
+      it 'returns the old values' do
+        expect(pt.default_cost_limitation_substantive).to eq 25_000.0
+        expect(pt.default_cost_limitation_delegated_functions).to eq 1350.0
+      end
+    end
+
+    describe 'after the change' do
+      let(:run_date) { Date.parse('2021-09-13') }
+
+      it 'returns the old values' do
+        expect(pt.default_cost_limitation_substantive).to eq 25_000.0
+        expect(pt.default_cost_limitation_delegated_functions).to eq 2250.0
+      end
     end
   end
 end


### PR DESCRIPTION
**What**
Add default costs and effective dates to proceeding types 
https://dsdmoj.atlassian.net/browse/AP-2451

**Why**
For LFA to become the source of truth for default costs and their effective dates

**How**
(Copying the current functionality from apply)
Created a new model default_cost_limitations
Populated this with data for substantive and delegated_functions proceeding_types (before and after 13/9/2021)
Added default_cost_limitation_delegated_functions and default_cost_limitation_substantive functions to proceeding_type model

