### PR TITLE
AP-2465: ProceedingType search update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'puma', '~> 5.5'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 # Api documentation
 gem 'apipie-rails', '>= 0.5.19'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -258,6 +260,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry-byebug
   puma (~> 5.5)
+  rack-cors
   rails (~> 6.1.4, >= 6.1.4.1)
   rspec-rails (~> 5.0, >= 5.0.2)
   rspec_junit_formatter

--- a/app/controllers/proceeding_types/searches_controller.rb
+++ b/app/controllers/proceeding_types/searches_controller.rb
@@ -33,7 +33,7 @@ module ProceedingTypes
     end
 
     api :POST, 'proceeding_types/search', 'Create a request to retrieve a list of proceeding types that match the search type'
-    param :search_term, String, required: true, desc: 'Search for proceeding types matching the `search_term`'
+    param :search_term, String, required: false, desc: 'Search for proceeding types matching the `search_term`'
 
     returns code: :ok, desc: 'Successful response' do
       property :success, ['true'], desc: 'Success flag shows true'
@@ -44,6 +44,11 @@ module ProceedingTypes
       property :success, ['false'], desc: 'Success flag shows false'
       property :error_class, String, desc: 'Name of the error class that caused the exception'
       property :message, String, desc: 'Error message'
+    end
+
+    def index
+      result = ProceedingType.all.map { |pt| JSON.parse(pt.api_json) }
+      render json: result.to_json, status: :ok
     end
 
     def create

--- a/app/controllers/proceeding_types/searches_controller.rb
+++ b/app/controllers/proceeding_types/searches_controller.rb
@@ -23,10 +23,10 @@ module ProceedingTypes
           ]
         }
 
-      Optionally you can send an excluded_terms value, this should be a comma separated string or codes to exclude, e.g.
+      Optionally you can send an excluded_codes value, this should be a comma separated string or codes to exclude, e.g.
         {
           "search_term": "Family",
-          "excluded_terms": "DA001,DA002"
+          "excluded_codes": "DA001,DA002"
         }
       This will return proceeding terms that match Family but exclude any proceeding types with matching codes
       END_OF_TEXT
@@ -73,7 +73,7 @@ module ProceedingTypes
 
     def build_results
       find = search_param
-      exclude = params['excluded_terms'] ||= []
+      exclude = params['excluded_codes'] ||= []
       @build_results ||= ProceedingTypeFullTextSearch.call(find, exclude)
     end
 

--- a/app/controllers/proceeding_types/searches_controller.rb
+++ b/app/controllers/proceeding_types/searches_controller.rb
@@ -52,18 +52,22 @@ module ProceedingTypes
     end
 
     def create
-      render status: status, json: { success: status.eql?(200) }.merge(results).to_json
+      render status: status, json: { success: success }.merge(results).to_json
     end
 
     private
 
+    def success
+      @success ||= status.eql?(200) && results.symbolize_keys[:data].count.positive?
+    end
+
     def status
-      @status ||= results.symbolize_keys[:data].blank? ? 400 : 200
+      @status ||= results.symbolize_keys[:error].present? ? 400 : 200
     end
 
     def results
       if build_results.empty?
-        { error: 'no matches found' }
+        { data: [] }
       else
         { data: build_results }
       end

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -39,6 +39,16 @@ class ProceedingType < ApplicationRecord
     FROM matter_types mt WHERE mt.id = proceeding_types.matter_type_id;
   UPDATESQL
 
+  def api_json
+    {
+      ccms_code: ccms_code,
+      meaning: meaning,
+      description: description,
+      ccms_category_law_code: matter_type.category_of_law,
+      ccms_matter_code: matter_type.code
+    }.to_json
+  end
+
   def self.populate
     ProceedingTypePopulator.call
     refresh_text_searchable

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -44,8 +44,9 @@ class ProceedingType < ApplicationRecord
       ccms_code: ccms_code,
       meaning: meaning,
       description: description,
-      ccms_category_law_code: matter_type.category_of_law,
-      ccms_matter_code: matter_type.code
+      ccms_category_law: matter_type.category_of_law,
+      ccms_matter_code: matter_type.code,
+      ccms_matter: matter_type.name
     }.to_json
   end
 

--- a/app/services/proceeding_type_full_text_search.rb
+++ b/app/services/proceeding_type_full_text_search.rb
@@ -10,12 +10,12 @@
 class ProceedingTypeFullTextSearch
   Result = Struct.new(:meaning, :ccms_code, :description, :ccms_category_law, :ccms_matter)
 
-  def self.call(search_terms, excluded_terms = [])
-    new(search_terms, excluded_terms).call
+  def self.call(search_terms, excluded_codes = [])
+    new(search_terms, excluded_codes).call
   end
 
-  def initialize(search_terms, excluded_terms = [])
-    @excluded_terms = excluded_terms
+  def initialize(search_terms, excluded_codes = [])
+    @excluded_codes = excluded_codes
     @ts_query = ts_query_transform(search_terms)
   end
 
@@ -26,7 +26,7 @@ class ProceedingTypeFullTextSearch
   private
 
   def already_selected_codes
-    @already_selected_codes ||= @excluded_terms.split(',')
+    @already_selected_codes ||= @excluded_codes.split(',')
   end
 
   def matching_results

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
-# Be sure to restart your server when you modify this file.
 
+# Be sure to restart your server when you modify this file.
 # Avoid CORS issues when API is called from the frontend app.
 # Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource '*', headers: :any, methods: %i[get post put patch delete options head]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   Rails.application.routes.draw do
     apipie
     resources :merits_tasks, param: :ccms_code, only: %i[create]
+    get 'proceeding_types/all', to: 'proceeding_types/searches#index'
     resources :proceeding_types, param: :ccms_code, only: %i[show]
     namespace :proceeding_types do
       resources :threshold_waivers, only: %i[create]

--- a/spec/requests/proceeding_types/searches_spec.rb
+++ b/spec/requests/proceeding_types/searches_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
       let(:expected_result) do
         {
           success: false,
-          error: 'no matches found'
+          data: []
         }
       end
 
       it 'returns an unsuccessful response' do
-        expect(response).to have_http_status(400)
+        expect(response).to have_http_status(200)
         expect(response.media_type).to eql('application/json')
         expect(JSON.parse(response.body)).to match_json_expression(expected_result)
       end
@@ -111,8 +111,8 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
       end
     end
 
-    context 'when sending excluded_codes' do
-      describe 'that should return a single match' do
+    context 'when excluded_codes matches' do
+      describe 'the single match' do
         before { subject }
         let(:params) do
           {
@@ -123,12 +123,12 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
         let(:expected_result) do
           {
             success: false,
-            error: 'no matches found'
+            data: []
           }
         end
 
         it 'returns an unsuccessful response' do
-          expect(response).to have_http_status(400)
+          expect(response).to have_http_status(200)
           expect(response.media_type).to eql('application/json')
           expect(JSON.parse(response.body)).to match_json_expression(expected_result)
         end

--- a/spec/requests/proceeding_types/searches_spec.rb
+++ b/spec/requests/proceeding_types/searches_spec.rb
@@ -2,8 +2,20 @@ require 'rails_helper'
 
 RSpec.describe 'ProceedingTypes/SearchController', type: :request do
   before { seed_live_data }
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  describe 'GET proceeding_types/all' do
+    subject { get proceeding_types_all_path, headers: headers }
+    before { subject }
+
+    it 'returns a successful response with all proceedingtypes' do
+      expect(response).to have_http_status(200)
+      expect(response.media_type).to eql('application/json')
+      expect(JSON.parse(response.body).count).to eq 12
+    end
+  end
+
   describe 'POST proceeding_types/search' do
-    let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
     let(:params) do
       {
         search_term: search_term

--- a/spec/requests/proceeding_types/searches_spec.rb
+++ b/spec/requests/proceeding_types/searches_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
         let(:params) do
           {
             search_term: 'injunction',
-            excluded_terms: 'DA001'
+            excluded_codes: 'DA001'
           }
         end
 
@@ -111,13 +111,13 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
       end
     end
 
-    context 'when sending excluded_terms' do
+    context 'when sending excluded_codes' do
       describe 'that should return a single match' do
         before { subject }
         let(:params) do
           {
             search_term: search_term,
-            excluded_terms: 'DA005'
+            excluded_codes: 'DA005'
           }
         end
         let(:expected_result) do

--- a/spec/services/proceeding_type_full_text_search_spec.rb
+++ b/spec/services/proceeding_type_full_text_search_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProceedingTypeFullTextSearch do
   context 'whole service' do
     before { seed_live_data }
-    let(:excluded_terms) { [] }
+    let(:excluded_codes) { [] }
 
     describe '.call' do
       subject { described_class.call(search_term) }
@@ -68,9 +68,9 @@ RSpec.describe ProceedingTypeFullTextSearch do
         end
 
         context 'when you send one of the codes as an excluded_term' do
-          subject { described_class.call(search_term, excluded_terms) }
+          subject { described_class.call(search_term, excluded_codes) }
 
-          let(:excluded_terms) { 'DA001' }
+          let(:excluded_codes) { 'DA001' }
 
           it 'returns two results' do
             result_set = subject


### PR DESCRIPTION
Addresses two issues:
## Update ProceedingTypeSearch with `all`
This allows Apply to request all proceeding types
It may end up getting deprecated in future but for now it will allow like-for-like replacement with the way Apply processes it's internal function

## Update exclusion parameter from excluded_term to excluded_codes
As I used the endpoint from apply it made more sense to rename it to excluded_codes as that is what we are expecting and using