### PR TITLE
Update dependabot to inlcude dependencies and run daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,10 @@ updates:
   open-pull-requests-limit: 10
 - package-ecosystem: npm
   directory: "/"
+  allow:
+    - dependency-type: "all"
   schedule:
-    interval: weekly
+    interval: daily
     day: wednesday
     time: "03:00"
     timezone: Europe/London


### PR DESCRIPTION
Update dependabot to check for updates in dependencies of dependencies. Run it daily at least initially to see how many PRs are being generated, may dial it back to weekly in the future.