### PR TITLE
Add name to proceeding_type

### DIFF
--- a/app/controllers/proceeding_types_controller.rb
+++ b/app/controllers/proceeding_types_controller.rb
@@ -20,6 +20,7 @@ class ProceedingTypesController < ApplicationController
     property :meaning, String, desc: 'The Proceeding Type meaning'
     property :ccms_category_law_code, String, desc: 'The Proceeding Type CCMS category of law code'
     property :ccms_matter_code, String, desc: 'The Proceeding Type CCMS matter code'
+    property :name, String, desc: 'The Proceeding Type name'
     property :description, String, desc: 'The Proceeding Type description'
     property :ccms_category_law, String, desc: 'The Proceeding Type CCMS category of law'
     property :ccms_matter, String, desc: 'The Proceeding Type CCMS matter type'

--- a/app/services/proceeding_type_populator.rb
+++ b/app/services/proceeding_type_populator.rb
@@ -12,18 +12,21 @@ class ProceedingTypePopulator
 
   private
 
+  # rubocop:disable Metrics/MethodLength
   def populate(seed_row)
-    ccms_code, meaning, description, matter_type_id_method, additional_search_terms = seed_row
+    ccms_code, meaning, name, description, matter_type_id_method, additional_search_terms = seed_row
     matter_type_id = __send__(matter_type_id_method)
     record = ProceedingType.find_by(ccms_code: ccms_code) || ProceedingType.new
     record.update!(
       ccms_code: ccms_code,
       meaning: meaning,
+      name: name,
       description: description,
       additional_search_terms: additional_search_terms,
       matter_type_id: matter_type_id
     )
   end
+  # rubocop:enable Metrics/MethodLength
 
   def domestic_abuse_id
     @domestic_abuse_id ||= MatterType.domestic_abuse.id

--- a/app/services/proceeding_type_service.rb
+++ b/app/services/proceeding_type_service.rb
@@ -23,20 +23,25 @@ class ProceedingTypeService
 
   def populate_response(ccms_code)
     pt = ProceedingType.find_by!(ccms_code: ccms_code)
+    add_matter_type_to_response(pt)
     add_proceeding_type_to_response(pt)
     add_cost_limitations_to_response(pt)
     add_scope_limitations_to_response(pt)
   end
 
-  def add_proceeding_type_to_response(proceeding_type)
+  def add_matter_type_to_response(proceeding_type)
     matter_type = proceeding_type.matter_type
-    @response[:ccms_code] = proceeding_type.ccms_code
-    @response[:meaning] = proceeding_type.meaning
     @response[:ccms_category_law_code] = matter_type.category_of_law_code
     @response[:ccms_matter_code] = matter_type.code
-    @response[:description] = proceeding_type.description
     @response[:ccms_category_law] = matter_type.category_of_law
     @response[:ccms_matter] = matter_type.name
+  end
+
+  def add_proceeding_type_to_response(proceeding_type)
+    @response[:ccms_code] = proceeding_type.ccms_code
+    @response[:meaning] = proceeding_type.meaning
+    @response[:name] = proceeding_type.name
+    @response[:description] = proceeding_type.description
   end
 
   def add_cost_limitations_to_response(proceeding_type)
@@ -77,6 +82,7 @@ class ProceedingTypeService
       meaning: '',
       ccms_category_law_code: '',
       ccms_matter_code: '',
+      name: '',
       description: '',
       ccms_category_law: '',
       ccms_matter: '',

--- a/db/migrate/20211005102214_add_searchable_fields_to_proceeding_types.rb
+++ b/db/migrate/20211005102214_add_searchable_fields_to_proceeding_types.rb
@@ -3,8 +3,6 @@ class AddSearchableFieldsToProceedingTypes < ActiveRecord::Migration[6.1]
     add_column :proceeding_types, :additional_search_terms, :string
     execute 'ALTER TABLE proceeding_types ADD COLUMN textsearchable tsvector'
     execute 'CREATE INDEX textsearch_idx ON proceeding_types USING GIN (textsearchable)'
-    MatterTypePopulator.call
-    ProceedingType.populate
   end
 
   def down

--- a/db/migrate/20211130102438_add_name_to_proceeding_types.rb
+++ b/db/migrate/20211130102438_add_name_to_proceeding_types.rb
@@ -1,0 +1,7 @@
+class AddNameToProceedingTypes < ActiveRecord::Migration[6.1]
+  # rubocop:disable Rails/NotNullColumn
+  def change
+    add_column :proceeding_types, :name, :string, null: false
+  end
+  # rubocop:enable Rails/NotNullColumn
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_06_152408) do
+ActiveRecord::Schema.define(version: 2021_11_30_102438) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2021_10_06_152408) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "additional_search_terms"
     t.tsvector "textsearchable"
+    t.string "name", null: false
     t.index ["textsearchable"], name: "textsearch_idx", using: :gin
   end
 

--- a/db/seed_data/proceeding_types.yml
+++ b/db/seed_data/proceeding_types.yml
@@ -2,45 +2,53 @@
 # List of proceeding types
 # - ccms_code
 # - meaning
+# - name
 # - description
 # - method to call to get the matter_type id
 # - additional_search_terms
 #
 - - DA006
   - Extend, variation or discharge - Part IV
+  - extend_variation_or_discharge_part_iv
   - to be represented on an application to extend, vary or discharge an order under
     Part IV Family Law Act 1996
   - domestic_abuse_id
   -
 - - DA007
   - Forced marriage protection order
+  - forced_marriage_protection_order
   - to be represented on an application for a forced marriage protection order
   - domestic_abuse_id
   -
 - - DA003
   - Harassment - injunction
+  - harassment_injunction
   - to be represented in an action for an injunction under section 3 Protection from
     Harassment Act 1997.
   - domestic_abuse_id
   -
 - - DA001
   - Inherent jurisdiction high court injunction
+  - inherent_jurisdiction_high_court_injunction
   - to be represented on an application for an injunction, order or declaration under
     the inherent jurisdiction of the court.
   - domestic_abuse_id
   -
 - - DA004
   - Non-molestation order
+  - nonmolestation_order
   - to be represented on an application for a non-molestation order.
   - domestic_abuse_id
   - harassment,injunction
 - - DA005
   - Occupation order
+  - occupation_order
   - to be represented on an application for an occupation order.
   - domestic_abuse_id
   -
 - - DA002
   - Variation or discharge under section 5 protection from harassment act 1997
+  - variation_or_discharge_under_section_protection_from_harassment_act
   - to be represented on an application to vary or discharge an order under section
     5 Protection from Harassment Act 1997 where the parties are associated persons
     (as defined by Part IV Family Law Act 1996).
@@ -48,28 +56,33 @@
   -
 - - DA020
   - FGM Protection Order
+  - fgm_protection_order
   - To be represented on an application for a Female Genital Mutilation Protection
     Order under the Female Genital Mutilation Act.
   - domestic_abuse_id
   -
 - - SE003
   - Prohibited steps order
+  - prohibited_steps_order_s8
   - to be represented on an application for a prohibited steps order.
   - section8_id
   -
 - - SE004
   - Specific Issue Order
+  - specified_issue_order_s8
   - to be represented on an application for a specific issue order.
   - section8_id
   -
 - - SE013
   - Child arrangements order (contact)
+  - child_arrangements_order_contact
   - to be represented on an application for a child arrangements order-who the child(ren)
     spend time with.
   - section8_id
   - cao
 - - SE014
   - Child arrangements order (residence)
+  - child_arrangements_order_residence
   - to be represented on an application for a child arrangements order –where the
     child(ren) will live
   - section8_id

--- a/spec/requests/proceeding_types_spec.rb
+++ b/spec/requests/proceeding_types_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe ProceedingTypesController, type: :request do
         meaning: 'Prohibited steps order',
         ccms_category_law_code: 'MAT',
         ccms_matter_code: 'KSEC8',
+        name: 'prohibited_steps_order_s8',
         description: 'to be represented on an application for a prohibited steps order.',
         ccms_category_law: 'Family',
         ccms_matter: 'Children - section 8',

--- a/spec/services/proceeding_type_service_spec.rb
+++ b/spec/services/proceeding_type_service_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe ProceedingTypeService do
     {
       success: true,
       ccms_code: 'DA003',
+      name: 'harassment_injunction',
       meaning: 'Harassment - injunction',
       ccms_category_law_code: 'MAT',
       ccms_matter_code: 'MINJN',


### PR DESCRIPTION
Apply uses the proceeding type name in a number of places (`proceedings_by_name` method on the LegalAidApplication model, for example. Currently this data isn't held in LFA.

This change

* adds the field to the model and updates seed data and populator so that the names is held in LFA.
* updates the proceeding type service and controller so that the name is returned for requests to the `proceeding_type` endpoint.