### PR TITLE
Set default name on proceeding_types

### DIFF
--- a/db/migrate/20211130102438_add_name_to_proceeding_types.rb
+++ b/db/migrate/20211130102438_add_name_to_proceeding_types.rb
@@ -1,7 +1,5 @@
 class AddNameToProceedingTypes < ActiveRecord::Migration[6.1]
-  # rubocop:disable Rails/NotNullColumn
   def change
-    add_column :proceeding_types, :name, :string, null: false
+    add_column :proceeding_types, :name, :string, null: false, default: 'default_name'
   end
-  # rubocop:enable Rails/NotNullColumn
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 2021_11_30_102438) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "additional_search_terms"
     t.tsvector "textsearchable"
-    t.string "name", null: false
+    t.string "name", default: "default_name", null: false
     t.index ["textsearchable"], name: "textsearch_idx", using: :gin
   end
 


### PR DESCRIPTION
Lack of a default name is causing issues when running migrations. This
adds a default name to existing records which will be overwritten when
data is seeded.