### PR TITLE
AP-2606 Update CircleCI Slack orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  slack: circleci/slack@3.4.2
+  slack: circleci/slack@4.4.4
 executors:
   basic-executor:
     docker:
@@ -116,29 +116,6 @@ references:
         bundle exec rake db:create db:schema:load
         bundle exec rake db:migrate
 
-commands:
-  hold-notification:
-    description: Notify Slack about an awaiting approval job
-    parameters:
-      message:
-        default: "$CIRCLE_USERNAME has a pending approval for $CIRCLE_BRANCH"
-        description: A workflow in CircleCI is awaiting approval.
-        type: string
-      url:
-        default: 'https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}'
-        description: The URL to link back to.
-        type: string
-      webhook:
-        default: '${SLACK_WEBHOOK}'
-        description: >-
-          Enter either your Webhook value or use the CircleCI UI to add your token
-          under the 'SLACK_WEBHOOK' env var
-        type: string
-    steps:
-      - slack/approval:
-          message: << parameters.message >>
-          webhook: << parameters.webhook >>
-
 jobs:
   lint_checks:
     executor: linting-executor
@@ -227,11 +204,6 @@ jobs:
                           --values ./deploy/helm/values-staging.yaml \
                           --set image.repository="$ECR_ENDPOINT/laa-apply-for-legal-aid/legal-framework-api-uat-ecr" \
                           --set image.tag="${CIRCLE_SHA1}"
-  hold_production_notification:
-    executor: notification-executor
-    steps:
-      - hold-notification:
-          message: "$CIRCLE_USERNAME has a pending Legal Framework API production approval for $CIRCLE_BRANCH"
   deploy_production:
     executor: cloud-platform-executor
     steps:
@@ -250,6 +222,12 @@ jobs:
                         --set image.repository="$ECR_ENDPOINT/laa-apply-for-legal-aid/legal-framework-api-uat-ecr" \
                         --set image.tag="${CIRCLE_SHA1}"
 
+generic-slack-fail-post-step: &generic-slack-fail-post-step
+  post-steps:
+    - slack/notify:
+        event: fail
+        template: basic_fail_1
+
 workflows:
   new_pull_request:
     jobs:
@@ -257,21 +235,25 @@ workflows:
           filters:
             branches:
               ignore: main
+          <<: *generic-slack-fail-post-step
       - unit_tests:
           filters:
             branches:
               ignore: main
+          <<: *generic-slack-fail-post-step
       - build_and_push:
           context: legal-framework-api-uat
           filters:
             branches:
               ignore: main
+          <<: *generic-slack-fail-post-step
       - deploy_uat:
           context: legal-framework-api-uat
           requires:
             - lint_checks
             - unit_tests
             - build_and_push
+          <<: *generic-slack-fail-post-step
 
   merge_pr:
     jobs:
@@ -279,36 +261,81 @@ workflows:
           filters:
             branches:
               only: main
+          <<: *generic-slack-fail-post-step
       - unit_tests:
           filters:
             branches:
               only: main
+          <<: *generic-slack-fail-post-step
       - build_and_push:
           requires:
             - lint_checks
             - unit_tests
+          <<: *generic-slack-fail-post-step
       - deploy_main_uat:
           context: legal-framework-api-uat
           requires:
             - build_and_push
+          <<: *generic-slack-fail-post-step
       - delete_uat_branch:
           context: legal-framework-api-uat
           requires:
             - deploy_main_uat
+          <<: *generic-slack-fail-post-step
       - deploy_staging:
           context: legal-framework-api-staging
           requires:
             - build_and_push
-      - hold_production_notification:
+          <<: *generic-slack-fail-post-step
+      - slack/on-hold:
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "plain_text",
+                    "text": ":circleci: $CIRCLE_USERNAME has a pending production approval for $CIRCLE_BRANCH"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Project*: $CIRCLE_PROJECT_REPONAME"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Pull Request*: $CIRCLE_PULL_REQUEST"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow"
+                      },
+                      "url": "https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+                    }
+                  ]
+                }
+              ]
+            }
           requires:
-            - delete_uat_branch
             - deploy_staging
       - hold_production:
           type: approval
           requires:
             - delete_uat_branch
             - deploy_staging
+            - slack/on-hold
       - deploy_production:
           context: legal-framework-api-production
           requires:
             - hold_production
+          <<: *generic-slack-fail-post-step


### PR DESCRIPTION
The CircleCI Slack Orb needs to be updated from `v3.4.2` to the latest version (`v4.4.4`). This is a breaking change and requires some reconfiguration to allow Slack notifications to continue to work:

* `SLACK_DEFAULT_CHANNE` and `SLACK_ACCESS_TOKEN` environment variables configured in CircleCI.

* CircleCI Slack Orb upgraded to `v4.4.4` in `.circleci/config.yml`.

* `hold_production_notification` command replaced with customised `slack/on-hold` command.

* Notifications for any failed workflow step enabled.