### PR TITLE
Tech debt: Prepare for rails 7

### DIFF
--- a/app/services/proceeding_type_full_text_search.rb
+++ b/app/services/proceeding_type_full_text_search.rb
@@ -32,7 +32,7 @@ class ProceedingTypeFullTextSearch
   def matching_results
     result_set = ProceedingType.connection.exec_query(query_string,
                                                       '-- PROCEEDING TYPE FULL TEXT SEARCH ---',
-                                                      [[nil, @ts_query]],
+                                                      [@ts_query],
                                                       prepare: true)
     result_set.map { |row| instantiate_result(row) }
   end

--- a/spec/requests/merits_tasks_spec.rb
+++ b/spec/requests/merits_tasks_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe MeritsTasksController, type: :request do
         expect(parsed_response[:request_id]).to eq request_id
         expect(parsed_response[:success]).to be false
         expect(parsed_response[:error_class]).to eq 'ActiveRecord::RecordNotFound'
-        expect(parsed_response[:message]).to eq "Couldn't find ProceedingType"
+        expect(parsed_response[:message]).to match(/Couldn't find ProceedingType/)
         expect(parsed_response[:backtrace]).to be_instance_of(Array)
       end
 
@@ -109,7 +109,7 @@ RSpec.describe MeritsTasksController, type: :request do
         expect(stored_response[:request_id]).to eq request_id
         expect(stored_response[:success]).to be false
         expect(stored_response[:error_class]).to eq 'ActiveRecord::RecordNotFound'
-        expect(stored_response[:message]).to eq "Couldn't find ProceedingType"
+        expect(stored_response[:message]).to match(/Couldn't find ProceedingType/)
         expect(stored_response[:backtrace]).to be_instance_of(Array)
       end
     end

--- a/spec/services/merits_task_service_spec.rb
+++ b/spec/services/merits_task_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe MeritsTaskService do
         expect(response[:request_id]).to eq request_id
         expect(response[:success]).to be false
         expect(response[:error_class]).to eq 'ActiveRecord::RecordNotFound'
-        expect(response[:message]).to eq "Couldn't find ProceedingType"
+        expect(response[:message]).to match(/Couldn't find ProceedingType/)
         expect(response[:backtrace]).to be_instance_of(Array)
       end
     end

--- a/spec/services/proceeding_type_service_spec.rb
+++ b/spec/services/proceeding_type_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ProceedingTypeService do
         response = subject
         expect(response[:success]).to be false
         expect(response[:error_class]).to eq 'ActiveRecord::RecordNotFound'
-        expect(response[:message]).to eq "Couldn't find ProceedingType"
+        expect(response[:message]).to match(/Couldn't find ProceedingType/)
         expect(response[:backtrace]).to be_instance_of(Array)
       end
     end


### PR DESCRIPTION
While assessing the Rails 7 PR for failures I did some investigating.

There were two issues, an error message change and a nested array issue in the full-text search
This PR addresses the two issues in Rails 6x in the hope that it will make the Rails 7 transition easier!
* In the full-text search, remove the nested array and replace it with a single-level array of variable to be searched for, without nil accompanying it
* The finder_method now returns an extended error message, see [this response](rails/rails#38956) The current method should currently fail in Rails 6.x (but doesn't) but it is definitely [failing in Rails 7+](https://github.com/ministryofjustice/legal-framework-api/pull/313)