### PR TITLE
AP-2771 Update ingress.yaml to use networking.k8s.io/v1

### DIFF
--- a/deploy/helm/templates/ingress.yaml
+++ b/deploy/helm/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- $fullName := include "app.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -24,7 +24,10 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: http
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
   {{- end }}


### PR DESCRIPTION
Updates i`ngress.yaml` to use `networking.k8s.io/v1` as a result of moving to the live cluster. This reconfigures the ingress using the new syntax.