### PR TITLE
Update bundler to v2.3.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,4 +298,4 @@ RUBY VERSION
    ruby 3.1.0p0
 
 BUNDLED WITH
-   2.2.24
+   2.3.5


### PR DESCRIPTION
Running any bundle command using the current version causes the following warning to be displayed:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, s
pell_checker)' instead.
```

This bumps bundler to the newest version which resolves this.