### PR TITLE
Remove more rubocop todos

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,13 +74,6 @@ Style/HashSyntax:
 Style/StringLiterals:
   Enabled: false
 
-# Offense count: 72
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Enabled: false
-
 # Offense count: 17
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, MinSize, WordRegex.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -73,18 +73,3 @@ Style/HashSyntax:
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
   Enabled: false
-
-# Offense count: 17
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, MinSize, WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  Exclude:
-    - 'app/controllers/merits_tasks_controller.rb'
-    - 'app/controllers/proceeding_types/searches_controller.rb'
-    - 'app/controllers/proceeding_types/threshold_waivers_controller.rb'
-    - 'app/controllers/proceeding_types_controller.rb'
-    - 'spec/requests/merits_tasks_spec.rb'
-    - 'spec/services/merits_task_service_spec.rb'
-    - 'spec/services/proceeding_type_service_spec.rb'
-    - 'spec/services/threshold_waiver_service_spec.rb'

--- a/app/controllers/merits_tasks_controller.rb
+++ b/app/controllers/merits_tasks_controller.rb
@@ -19,7 +19,7 @@ class MeritsTasksController < ApplicationController
 
   returns code: :ok, desc: 'Successful response' do
     property :request_id, :uuid, desc: 'The request_id specified in the request'
-    property :success, ['true'], desc: 'Success flag shows true'
+    property :success, %w[true], desc: 'Success flag shows true'
     property :application, Hash, desc: 'Merits tasks required at the application level' do
       property :tasks, Hash, desc: 'List of tasks and dependencies' do
         property :task_and_dependency, Hash, desc: 'Hash of key value pairs where the key is the task name, and the value is an array of dependencies'
@@ -35,7 +35,7 @@ class MeritsTasksController < ApplicationController
 
   returns code: :bad_request do
     property :request_id, :uuid, desc: 'The request_id specified in the request'
-    property :success, ['false'], desc: 'Success flag shows false'
+    property :success, %w[false], desc: 'Success flag shows false'
     property :error_class, String, desc: 'Name of the error class that caused the exception'
     property :message, String, desc: 'Error message'
     property :backtrace, array_of: String, desc: 'Backtrace of exception'

--- a/app/controllers/proceeding_types/searches_controller.rb
+++ b/app/controllers/proceeding_types/searches_controller.rb
@@ -36,12 +36,12 @@ module ProceedingTypes
     param :search_term, String, required: false, desc: 'Search for proceeding types matching the `search_term`'
 
     returns code: :ok, desc: 'Successful response' do
-      property :success, ['true'], desc: 'Success flag shows true'
+      property :success, %w[true], desc: 'Success flag shows true'
       property :data, array_of: String, desc: 'Returns an array of matching proceeding types'
     end
 
     returns code: :bad_request do
-      property :success, ['false'], desc: 'Success flag shows false'
+      property :success, %w[false], desc: 'Success flag shows false'
       property :error_class, String, desc: 'Name of the error class that caused the exception'
       property :message, String, desc: 'Error message'
     end

--- a/app/controllers/proceeding_types/threshold_waivers_controller.rb
+++ b/app/controllers/proceeding_types/threshold_waivers_controller.rb
@@ -19,7 +19,7 @@ module ProceedingTypes
 
     returns code: :ok, desc: 'Successful response' do
       property :request_id, :uuid, desc: 'The request_id specified in the request'
-      property :success, ['true'], desc: 'Success flag shows true'
+      property :success, %w[true], desc: 'Success flag shows true'
       property :proceeding_types, Array, desc: 'Proceeding typs and their associated whether their threshold information' do
         property :ccms_code, String, desc: 'The CCMS_code of the proceeding type'
         property :gross_income_upper, String
@@ -31,7 +31,7 @@ module ProceedingTypes
 
     returns code: :bad_request do
       property :request_id, :uuid, desc: 'The request_id specified in the request'
-      property :success, ['false'], desc: 'Success flag shows false'
+      property :success, %w[false], desc: 'Success flag shows false'
       property :error_class, String, desc: 'Name of the error class that caused the exception'
       property :message, String, desc: 'Error message'
       property :backtrace, array_of: String, desc: 'Backtrace of exception'

--- a/app/controllers/proceeding_types_controller.rb
+++ b/app/controllers/proceeding_types_controller.rb
@@ -16,7 +16,7 @@ class ProceedingTypesController < ApplicationController
 
   returns code: :ok, desc: 'Successful response' do
     property :ccms_code, String, desc: 'The ccms_code specified in the request'
-    property :success, ['true'], desc: 'Success flag shows true'
+    property :success, %w[true], desc: 'Success flag shows true'
     property :meaning, String, desc: 'The Proceeding Type meaning'
     property :ccms_category_law_code, String, desc: 'The Proceeding Type CCMS category of law code'
     property :ccms_matter_code, String, desc: 'The Proceeding Type CCMS matter code'
@@ -50,7 +50,7 @@ class ProceedingTypesController < ApplicationController
 
   returns code: :bad_request do
     property :request_id, :uuid, desc: 'The request_id specified in the request'
-    property :success, ['false'], desc: 'Success flag shows false'
+    property :success, %w[false], desc: 'Success flag shows false'
     property :error_class, String, desc: 'Name of the error class that caused the exception'
     property :message, String, desc: 'Error message'
     property :backtrace, array_of: String, desc: 'Backtrace of exception'

--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -1,7 +1,7 @@
 class StatusController < ApplicationController
   def status
     checks = {
-      database: database_alive?
+      database: database_alive?,
     }
     status = :bad_gateway unless checks.values.all?
     render status: status, json: { checks: }
@@ -11,7 +11,7 @@ class StatusController < ApplicationController
     render json: {
       'build_date' => Rails.configuration.x.status.build_date,
       'build_tag' => Rails.configuration.x.status.build_tag,
-      'app_branch' => Rails.configuration.x.status.app_branch
+      'app_branch' => Rails.configuration.x.status.app_branch,
     }
   end
 

--- a/app/models/default_cost_limitation.rb
+++ b/app/models/default_cost_limitation.rb
@@ -3,7 +3,7 @@ class DefaultCostLimitation < ApplicationRecord
 
   enum cost_type: {
     delegated_functions: 'delegated_functions'.freeze,
-    substantive: 'substantive'.freeze
+    substantive: 'substantive'.freeze,
   }
 
   def self.for_date(date)

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -46,7 +46,7 @@ class ProceedingType < ApplicationRecord
       description: description,
       ccms_category_law: matter_type.category_of_law,
       ccms_matter_code: matter_type.code,
-      ccms_matter: matter_type.name
+      ccms_matter: matter_type.name,
     }.to_json
   end
 

--- a/app/services/merits_task_service.rb
+++ b/app/services/merits_task_service.rb
@@ -27,9 +27,9 @@ private
       request_id: @request_id,
       success: true,
       application: {
-        tasks: {}
+        tasks: {},
       },
-      proceeding_types: []
+      proceeding_types: [],
     }
   end
 
@@ -59,7 +59,7 @@ private
       success: false,
       error_class: err.class.to_s,
       message: err.message,
-      backtrace: err.backtrace
+      backtrace: err.backtrace,
     }
   end
 end

--- a/app/services/proceeding_type_service.rb
+++ b/app/services/proceeding_type_service.rb
@@ -87,7 +87,7 @@ private
       ccms_category_law: '',
       ccms_matter: '',
       cost_limitations: {},
-      default_scope_limitations: {}
+      default_scope_limitations: {},
     }
   end
 
@@ -97,7 +97,7 @@ private
       success: false,
       error_class: err.class.to_s,
       message: err.message,
-      backtrace: err.backtrace
+      backtrace: err.backtrace,
     }
   end
 end

--- a/app/services/threshold_waiver_service.rb
+++ b/app/services/threshold_waiver_service.rb
@@ -26,7 +26,7 @@ private
     {
       request_id: @request_id,
       success: true,
-      proceeding_types: []
+      proceeding_types: [],
     }
   end
 
@@ -42,7 +42,7 @@ private
       gross_income_upper: proceeding_type.matter_type.upper_gross_income_waiver,
       disposable_income_upper: proceeding_type.matter_type.upper_disposable_income_waiver,
       capital_upper: proceeding_type.matter_type.upper_capital_waiver,
-      matter_type: proceeding_type.matter_type.name
+      matter_type: proceeding_type.matter_type.name,
     }
 
     @response[:proceeding_types] << tw_hash
@@ -54,7 +54,7 @@ private
       success: false,
       error_class: err.class.to_s,
       message: err.message,
-      backtrace: err.backtrace
+      backtrace: err.backtrace,
     }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   if Rails.root.join('tmp/caching-dev.txt').exist?
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      'Cache-Control' => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.

--- a/db/populators/proceeding_type_scope_limitations_populator.rb
+++ b/db/populators/proceeding_type_scope_limitations_populator.rb
@@ -32,7 +32,7 @@ private
       proceeding_type_id: proceeding_type_id(seed_row),
       scope_limitation_id: scope_limitation_id(seed_row),
       substantive_default: seed_row[2],
-      delegated_functions_default: seed_row[3]
+      delegated_functions_default: seed_row[3],
     }
   end
 

--- a/spec/requests/merits_tasks_spec.rb
+++ b/spec/requests/merits_tasks_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MeritsTasksController, type: :request do
     let(:params) do
       {
         request_id:,
-        proceeding_types:
+        proceeding_types:,
       }
     end
 
@@ -50,33 +50,33 @@ RSpec.describe MeritsTasksController, type: :request do
               'latest_incident_details' => [],
               'opponent_details' => [],
               'statement_of_case' => [],
-              'children_application' => []
-            }
+              'children_application' => [],
+            },
           },
           proceeding_types: [
             {
               ccms_code: 'DA005',
               tasks: {
-                'chances_of_success' => []
-              }
+                'chances_of_success' => [],
+              },
             },
             {
               ccms_code: 'SE004',
               tasks: {
                 'chances_of_success' => [],
                 'children_proceeding' => ['children_application'],
-                'attempts_to_settle' => []
-              }
+                'attempts_to_settle' => [],
+              },
             },
             {
               ccms_code: 'SE013',
               tasks: {
                 'chances_of_success' => [],
                 'children_proceeding' => ['children_application'],
-                'attempts_to_settle' => []
-              }
+                'attempts_to_settle' => [],
+              },
             },
-          ]
+          ],
         }
       end
     end

--- a/spec/requests/merits_tasks_spec.rb
+++ b/spec/requests/merits_tasks_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe MeritsTasksController, type: :request do
               ccms_code: 'SE004',
               tasks: {
                 'chances_of_success' => [],
-                'children_proceeding' => ['children_application'],
+                'children_proceeding' => %w[children_application],
                 'attempts_to_settle' => [],
               },
             },
@@ -72,7 +72,7 @@ RSpec.describe MeritsTasksController, type: :request do
               ccms_code: 'SE013',
               tasks: {
                 'chances_of_success' => [],
-                'children_proceeding' => ['children_application'],
+                'children_proceeding' => %w[children_application],
                 'attempts_to_settle' => [],
               },
             },

--- a/spec/requests/proceeding_types/searches_spec.rb
+++ b/spec/requests/proceeding_types/searches_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
 
     let(:params) do
       {
-        search_term: search_term
+        search_term: search_term,
       }
     end
     let(:search_term) { 'Occupation' }
@@ -39,9 +39,9 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
               ccms_code: 'DA005',
               description: 'to be represented on an application for an occupation order.',
               ccms_category_law: 'Family',
-              ccms_matter: 'Domestic abuse'
+              ccms_matter: 'Domestic abuse',
             },
-          ]
+          ],
         }
       end
 
@@ -59,7 +59,7 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
       let(:expected_result) do
         {
           success: false,
-          data: []
+          data: [],
         }
       end
 
@@ -80,7 +80,7 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
         {
           success: false,
           error: 'StandardError',
-          message: 'Unexpected error in full text search'
+          message: 'Unexpected error in full text search',
         }
       end
 
@@ -106,7 +106,7 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
         let(:params) do
           {
             search_term: 'injunction',
-            excluded_codes: 'DA001'
+            excluded_codes: 'DA001',
           }
         end
 
@@ -125,13 +125,13 @@ RSpec.describe 'ProceedingTypes/SearchController', type: :request do
         let(:params) do
           {
             search_term: search_term,
-            excluded_codes: 'DA005'
+            excluded_codes: 'DA005',
           }
         end
         let(:expected_result) do
           {
             success: false,
-            data: []
+            data: [],
           }
         end
 

--- a/spec/requests/proceeding_types/threshold_waivers_spec.rb
+++ b/spec/requests/proceeding_types/threshold_waivers_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'ProceedingTypes/ThresholdWaiversController', type: :request do
     let(:params) do
       {
         request_id: request_id,
-        proceeding_types: proceeding_types
+        proceeding_types: proceeding_types,
       }
     end
     let(:proceeding_types) { %w[DA005 SE004 SE013] }
@@ -52,23 +52,23 @@ RSpec.describe 'ProceedingTypes/ThresholdWaiversController', type: :request do
               gross_income_upper: true,
               disposable_income_upper: true,
               capital_upper: true,
-              matter_type: 'Domestic abuse'
+              matter_type: 'Domestic abuse',
             },
             {
               ccms_code: 'SE004',
               gross_income_upper: false,
               disposable_income_upper: false,
               capital_upper: false,
-              matter_type: 'Children - section 8'
+              matter_type: 'Children - section 8',
             },
             {
               ccms_code: 'SE013',
               gross_income_upper: false,
               disposable_income_upper: false,
               capital_upper: false,
-              matter_type: 'Children - section 8'
+              matter_type: 'Children - section 8',
             },
-          ]
+          ],
         }
       end
     end

--- a/spec/requests/proceeding_types_spec.rb
+++ b/spec/requests/proceeding_types_spec.rb
@@ -37,27 +37,27 @@ RSpec.describe ProceedingTypesController, type: :request do
         cost_limitations: {
           substantive: {
             start_date: '1970-01-01',
-            value: '25000.0'
+            value: '25000.0',
           },
           delegated_functions: {
             start_date: '2021-09-13',
-            value: '2250.0'
-          }
+            value: '2250.0',
+          },
         },
         default_scope_limitations: {
           substantive: {
             code: 'FM059',
             meaning: 'FHH Children',
             description: 'Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement.'\
-                         ' To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.'
+                         ' To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.',
           },
           delegated_functions: {
             code: 'CV117',
             meaning: 'Interim order inc. return date',
             description: 'Limited to all steps necessary to apply for an interim order;'\
-                         ' where application is made without notice to include representation on the return date.'
-          }
-        }
+                         ' where application is made without notice to include representation on the return date.',
+          },
+        },
       }
     end
 

--- a/spec/services/merits_task_service_spec.rb
+++ b/spec/services/merits_task_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MeritsTaskService do
 
   context 'successful_response' do
     context 'domestic abuse proceeding type' do
-      let(:ccms_codes) { ['DA005'] }
+      let(:ccms_codes) { %w[DA005] }
 
       it 'returns valid response with expected tasks' do
         expect(subject).to eq expected_da005_response
@@ -27,7 +27,7 @@ RSpec.describe MeritsTaskService do
 
   context 'error response' do
     context 'non_existent ccms_code' do
-      let(:ccms_codes) { ['XX001'] }
+      let(:ccms_codes) { %w[XX001] }
 
       it 'returns error' do
         response = subject
@@ -98,7 +98,7 @@ RSpec.describe MeritsTaskService do
           ccms_code: 'SE003',
           tasks: {
             'chances_of_success' => [],
-            'children_proceeding' => ['children_application'],
+            'children_proceeding' => %w[children_application],
             'attempts_to_settle' => [],
           },
         },
@@ -106,7 +106,7 @@ RSpec.describe MeritsTaskService do
           ccms_code: 'SE013',
           tasks: {
             'chances_of_success' => [],
-            'children_proceeding' => ['children_application'],
+            'children_proceeding' => %w[children_application],
             'attempts_to_settle' => [],
           },
         },

--- a/spec/services/merits_task_service_spec.rb
+++ b/spec/services/merits_task_service_spec.rb
@@ -61,17 +61,17 @@ RSpec.describe MeritsTaskService do
         tasks: {
           'latest_incident_details' => [],
           'opponent_details' => [],
-          'statement_of_case' => []
-        }
+          'statement_of_case' => [],
+        },
       },
       proceeding_types: [
         {
           ccms_code: 'DA005',
           tasks: {
-            'chances_of_success' => []
-          }
+            'chances_of_success' => [],
+          },
         },
-      ]
+      ],
     }
   end
 
@@ -84,33 +84,33 @@ RSpec.describe MeritsTaskService do
           'latest_incident_details' => [],
           'opponent_details' => [],
           'statement_of_case' => [],
-          'children_application' => []
-        }
+          'children_application' => [],
+        },
       },
       proceeding_types: [
         {
           ccms_code: 'DA005',
           tasks: {
-            'chances_of_success' => []
-          }
+            'chances_of_success' => [],
+          },
         },
         {
           ccms_code: 'SE003',
           tasks: {
             'chances_of_success' => [],
             'children_proceeding' => ['children_application'],
-            'attempts_to_settle' => []
-          }
+            'attempts_to_settle' => [],
+          },
         },
         {
           ccms_code: 'SE013',
           tasks: {
             'chances_of_success' => [],
             'children_proceeding' => ['children_application'],
-            'attempts_to_settle' => []
-          }
+            'attempts_to_settle' => [],
+          },
         },
-      ]
+      ],
     }
   end
 end

--- a/spec/services/proceeding_type_service_spec.rb
+++ b/spec/services/proceeding_type_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProceedingTypeService do
   before { seed_live_data }
 
   context 'successful_response' do
-    let(:ccms_code) { ['DA003'] }
+    let(:ccms_code) { %w[DA003] }
 
     it 'returns valid response with expected tasks' do
       expect(subject).to eq expected_da003_response

--- a/spec/services/proceeding_type_service_spec.rb
+++ b/spec/services/proceeding_type_service_spec.rb
@@ -54,12 +54,12 @@ RSpec.describe ProceedingTypeService do
       cost_limitations: {
         substantive: {
           start_date: '1970-01-01',
-          value: '25000.0'
+          value: '25000.0',
         },
         delegated_functions: {
           start_date: '2021-09-13',
-          value: '2250.0'
-        }
+          value: '2250.0',
+        },
       },
       default_scope_limitations: {
         substantive: {
@@ -71,15 +71,15 @@ RSpec.describe ProceedingTypeService do
                        ' to the exercise of a power of arrest to representation on'\
                        ' the consideration of the breach by the court (but excluding'\
                        ' applying for a warrant of arrest, if not attached, and'\
-                       ' representation in contempt proceedings).'
+                       ' representation in contempt proceedings).',
         },
         delegated_functions: {
           code: 'CV117',
           meaning: 'Interim order inc. return date',
           description: 'Limited to all steps necessary to apply for an interim order;'\
-                       ' where application is made without notice to include representation on the return date.'
-        }
-      }
+                       ' where application is made without notice to include representation on the return date.',
+        },
+      },
     }
   end
 end

--- a/spec/services/threshold_waiver_service_spec.rb
+++ b/spec/services/threshold_waiver_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ThresholdWaiverService do
 
   context 'successful_response' do
     context 'domestic abuse proceeding type' do
-      let(:ccms_codes) { ['DA005'] }
+      let(:ccms_codes) { %w[DA005] }
 
       it 'returns valid response with expected tasks' do
         expect(subject).to eq expected_da005_response
@@ -27,7 +27,7 @@ RSpec.describe ThresholdWaiverService do
 
   context 'error response' do
     context 'non_existent ccms_code' do
-      let(:ccms_codes) { ['XX001'] }
+      let(:ccms_codes) { %w[XX001] }
 
       it 'returns error' do
         response = subject

--- a/spec/services/threshold_waiver_service_spec.rb
+++ b/spec/services/threshold_waiver_service_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe ThresholdWaiverService do
           capital_upper: true,
           disposable_income_upper: true,
           gross_income_upper: true,
-          matter_type: 'Domestic abuse'
+          matter_type: 'Domestic abuse',
         },
-      ]
+      ],
     }
   end
 
@@ -79,23 +79,23 @@ RSpec.describe ThresholdWaiverService do
           capital_upper: true,
           disposable_income_upper: true,
           gross_income_upper: true,
-          matter_type: 'Domestic abuse'
+          matter_type: 'Domestic abuse',
         },
         {
           ccms_code: 'SE003',
           capital_upper: false,
           disposable_income_upper: false,
           gross_income_upper: false,
-          matter_type: 'Children - section 8'
+          matter_type: 'Children - section 8',
         },
         {
           ccms_code: 'SE013',
           capital_upper: false,
           disposable_income_upper: false,
           gross_income_upper: false,
-          matter_type: 'Children - section 8'
+          matter_type: 'Children - section 8',
         },
-      ]
+      ],
     }
   end
 end


### PR DESCRIPTION
Removes the `Style/TrailingCommaInHashLiteral` and `Style/WordArray` cops from the `.rubocop_todo` file and fixes resulting offences.