### PR TITLE
Add PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,17 @@
+
+## What
+
+[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)
+
+Describe what you did and why.
+
+## Checklist
+
+Before you ask people to review this PR:
+
+- Tests and rubocop should be passing: `bundle exec rake`
+- Github should not be reporting conflicts; you should have recently run `git rebase main`.
+- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
+- The PR description should say what you changed and why, with a link to the JIRA story.
+- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
+- You should have checked that the commit messages say why the change was made.


### PR DESCRIPTION
Brings the repo in line with Apply, CFE and the HMRC Interface by adding a template for pull requests.