### PR TITLE
TechDebt: Move rspec-rails gem to fix default Rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :test do
   gem "json_expressions"
   gem "pry-byebug"
   gem "rspec_junit_formatter"
+  gem "rspec-rails", "~> 5.1"
   gem "rubocop-govuk", require: false
   gem "rubocop-performance"
 end
@@ -52,7 +53,6 @@ end
 
 group :test do
   gem "highline"
-  gem "rspec-rails", "~> 5.1"
   gem "simplecov", require: false
   gem "simplecov-rcov"
 end


### PR DESCRIPTION
## What

The `default` Rake task (i.e. running `bundle exec rake`) is set up to run rubocop and rspec sequentially however stops after rubocop completes. This is because the `rspec-rails` gem only exists in the `:test` group in the Gemfile.

This change moves the gem to the `:development, :test` group where it can be accessed by Rake and run correctly.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
