### PR TITLE
AP-2859-allow-uppercase-in-branch-names

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -2,7 +2,7 @@
 
 deploy() {
   IMG_REPO="$ECR_ENDPOINT/laa-apply-for-legal-aid/legal-framework-api-uat-ecr"
-  RELEASE_NAME=$(echo $CIRCLE_BRANCH | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
+  RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   LEGACY_RELEASE_HOST="$RELEASE_NAME-legal-framework-uat.apps.live-1.cloud-platform.service.justice.gov.uk"
   RELEASE_HOST="$RELEASE_NAME-legal-framework-uat.cloud-platform.service.justice.gov.uk"
   IDENTIFIER="$RELEASE_NAME-legal-framework-api-legal-framework-api-uat-green"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/c/projects/AP/boards/233?modal=detail&selectedIssue=AP-2859)

UAT deployments fail if GitHub branch names contain a capital letter; down case branch names in deploy script to prevent this.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
