### PR TITLE
Fix: ProceedingType populator called with seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,9 @@ Dir[Rails.root.join("db/populators/*.rb")].sort.each do |seed_file|
 end
 
 MatterTypePopulator.call
-ProceedingTypePopulator.call
+# The following calls ProceedingTypePopulator.call
+# and ensures the textsearchable field is populated
+ProceedingType.populate
 MeritsTaskPopulator.call
 ProceedingTypeMeritsTaskPopulator.call
 TaskDependencyPopulator.call


### PR DESCRIPTION
## What

Internally this runs ProceedingTypePopulator.call and ensures the`textsearchable` field is populated and allow the search endpoints to run

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
