### PR TITLE
Fix: Update the references to the search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The documentation and input validation is maintained via
 A client will create a request by posting a payload to the `merits_tasks` endpoint, which will respond with the information required by the LAA to assess the 
 merits and means of the client for their specific proceeding type.
 
-`/proceeding_types/search`
+`/proceeding_types/searches`
 A client will create a payload with some search terms and the API will respond with an array of relevant proceeding types, which include those search terms in their name, description or meaning
 
 `/proceeding_types/threshold_waivers`

--- a/app/controllers/proceeding_types/searches_controller.rb
+++ b/app/controllers/proceeding_types/searches_controller.rb
@@ -32,7 +32,7 @@ module ProceedingTypes
       END_OF_TEXT
     end
 
-    api :POST, "proceeding_types/search", "Create a request to retrieve a list of proceeding types that match the search type"
+    api :POST, "proceeding_types/searches", "Create a request to retrieve a list of proceeding types that match the search type"
     param :search_term, String, required: false, desc: "Search for proceeding types matching the `search_term`"
 
     returns code: :ok, desc: "Successful response" do

--- a/spec/requests/proceeding_types/searches_spec.rb
+++ b/spec/requests/proceeding_types/searches_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "ProceedingTypes/SearchController", type: :request do
     end
   end
 
-  describe "POST proceeding_types/search" do
+  describe "POST proceeding_types/searches" do
     subject(:proceeding_types_post_request) { post proceeding_types_searches_path, params: params.to_json, headers: headers }
 
     let(:params) do


### PR DESCRIPTION
## What

This was created as /search originally but then renamed, the
documentation was not updated to match

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
