### PR TITLE
[AP-3078] Expose service_levels on proceeding_type details

### DIFF
--- a/app/services/proceeding_type_service.rb
+++ b/app/services/proceeding_type_service.rb
@@ -27,6 +27,7 @@ private
     add_proceeding_type_to_response(pt)
     add_cost_limitations_to_response(pt)
     add_scope_limitations_to_response(pt)
+    add_service_levels_to_response(pt)
   end
 
   def add_matter_type_to_response(proceeding_type)
@@ -56,6 +57,13 @@ private
     dfcl = delegated_functions_scope_limitations(proceeding_type)
     @response[:default_scope_limitations] = { substantive: { code: scl.code, meaning: scl.meaning, description: scl.description },
                                               delegated_functions: { code: dfcl.code, meaning: dfcl.meaning, description: dfcl.description } }
+  end
+
+  def add_service_levels_to_response(proceeding_type)
+    @response[:service_levels] = []
+    proceeding_type.service_levels.each do |lvl|
+      @response[:service_levels] << { level: lvl.level, name: lvl.name, stage: lvl.stage, proceeding_default: lvl.proceeding_default }
+    end
   end
 
   def delegated_functions_cost_limitations(proceeding_type)

--- a/app/services/proceeding_type_service.rb
+++ b/app/services/proceeding_type_service.rb
@@ -13,7 +13,7 @@ class ProceedingTypeService
   def call
     raise ProceedingTypeServiceError, "Must specify a proceeding type" if @ccms_code.nil?
 
-    populate_response(@ccms_code)
+    populate_response
     @response
   rescue StandardError => e
     @response = error_response_for(e)
@@ -21,16 +21,15 @@ class ProceedingTypeService
 
 private
 
-  def populate_response(ccms_code)
-    pt = ProceedingType.find_by!(ccms_code:)
-    add_matter_type_to_response(pt)
-    add_proceeding_type_to_response(pt)
-    add_cost_limitations_to_response(pt)
-    add_scope_limitations_to_response(pt)
-    add_service_levels_to_response(pt)
+  def populate_response
+    add_matter_type_to_response
+    add_proceeding_type_to_response
+    add_cost_limitations_to_response
+    add_scope_limitations_to_response
+    add_service_levels_to_response
   end
 
-  def add_matter_type_to_response(proceeding_type)
+  def add_matter_type_to_response
     matter_type = proceeding_type.matter_type
     @response[:ccms_category_law_code] = matter_type.category_of_law_code
     @response[:ccms_matter_code] = matter_type.code
@@ -38,48 +37,51 @@ private
     @response[:ccms_matter] = matter_type.name
   end
 
-  def add_proceeding_type_to_response(proceeding_type)
+  def add_proceeding_type_to_response
     @response[:ccms_code] = proceeding_type.ccms_code
     @response[:meaning] = proceeding_type.meaning
     @response[:name] = proceeding_type.name
     @response[:description] = proceeding_type.description
   end
 
-  def add_cost_limitations_to_response(proceeding_type)
-    scl = substantive_cost_limitations(proceeding_type)
-    dfcl = delegated_functions_cost_limitations(proceeding_type)
+  def add_cost_limitations_to_response
+    scl = substantive_cost_limitations
+    dfcl = delegated_functions_cost_limitations
     @response[:cost_limitations] = { substantive: { start_date: scl.start_date.to_s, value: scl.value.to_s },
                                      delegated_functions: { start_date: dfcl.start_date.to_s, value: dfcl.value.to_s } }
   end
 
-  def add_scope_limitations_to_response(proceeding_type)
-    scl = substantive_scope_limitations(proceeding_type)
-    dfcl = delegated_functions_scope_limitations(proceeding_type)
+  def add_scope_limitations_to_response
+    scl = substantive_scope_limitations
+    dfcl = delegated_functions_scope_limitations
     @response[:default_scope_limitations] = { substantive: { code: scl.code, meaning: scl.meaning, description: scl.description },
                                               delegated_functions: { code: dfcl.code, meaning: dfcl.meaning, description: dfcl.description } }
   end
 
-  def add_service_levels_to_response(proceeding_type)
-    @response[:service_levels] = []
+  def add_service_levels_to_response
     proceeding_type.service_levels.each do |lvl|
       @response[:service_levels] << { level: lvl.level, name: lvl.name, stage: lvl.stage, proceeding_default: lvl.proceeding_default }
     end
   end
 
-  def delegated_functions_cost_limitations(proceeding_type)
+  def delegated_functions_cost_limitations
     proceeding_type.default_cost_limitations.delegated_functions.for_date(Time.zone.today)
   end
 
-  def substantive_cost_limitations(proceeding_type)
+  def substantive_cost_limitations
     proceeding_type.default_cost_limitations.substantive.for_date(Time.zone.today)
   end
 
-  def delegated_functions_scope_limitations(proceeding_type)
+  def delegated_functions_scope_limitations
     proceeding_type.proceeding_type_scope_limitations.default_delegated_functions_scope_limitation
   end
 
-  def substantive_scope_limitations(proceeding_type)
+  def substantive_scope_limitations
     proceeding_type.proceeding_type_scope_limitations.default_substantive_scope_limitation
+  end
+
+  def proceeding_type
+    @proceeding_type ||= ProceedingType.find_by!(ccms_code: @ccms_code)
   end
 
   def skeleton_response
@@ -96,6 +98,7 @@ private
       ccms_matter: "",
       cost_limitations: {},
       default_scope_limitations: {},
+      service_levels: [],
     }
   end
 

--- a/spec/requests/proceeding_types_spec.rb
+++ b/spec/requests/proceeding_types_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ProceedingTypesController, type: :request do
+RSpec.describe "ProceedingTypesController", type: :request do
   describe "GET /proceeding_types/{code}" do
     subject(:proceeding_type_get_request) { get proceeding_type_path(ccms_code), headers: }
 
@@ -58,6 +58,20 @@ RSpec.describe ProceedingTypesController, type: :request do
                          " where application is made without notice to include representation on the return date.",
           },
         },
+        service_levels: [
+          {
+            level: 3,
+            name: "Full Representation",
+            stage: 8,
+            proceeding_default: false,
+          },
+          {
+            level: 1,
+            name: "Family Help (Higher)",
+            stage: 1,
+            proceeding_default: true,
+          },
+        ],
       }
     end
 

--- a/spec/services/proceeding_type_service_spec.rb
+++ b/spec/services/proceeding_type_service_spec.rb
@@ -1,20 +1,28 @@
 require "rails_helper"
 
 RSpec.describe ProceedingTypeService do
-  subject(:proceeding_type_service_response) { described_class.call(ccms_code) }
+  describe ".call" do
+    subject(:proceeding_type_service_response) { described_class.call(ccms_code) }
 
-  before { seed_live_data }
+    before { seed_live_data }
 
-  context "when the request is successful" do
-    let(:ccms_code) { %w[DA003] }
+    context "with a valid proceeding that has just one service level" do
+      let(:ccms_code) { %w[DA003] }
 
-    it "returns valid response with expected tasks" do
-      expect(proceeding_type_service_response).to eq expected_da003_response
+      it "returns valid response with expected tasks" do
+        expect(proceeding_type_service_response).to eq expected_da003_response
+      end
     end
-  end
 
-  context "when the request is unsuccessful" do
-    context "with a non_existent ccms_code" do
+    context "with a valid proceeding that has multiple service levels" do
+      let(:ccms_code) { %w[SE003] }
+
+      it "returns valid response with expected tasks" do
+        expect(proceeding_type_service_response).to eq expected_se003_response
+      end
+    end
+
+    context "with a non-existent ccms_code" do
       let(:ccms_code) { "XX001" }
 
       it "returns error" do
@@ -26,7 +34,7 @@ RSpec.describe ProceedingTypeService do
       end
     end
 
-    context "with no ccms codes specified" do
+    context "with no ccms_code specified" do
       let(:ccms_code) { nil }
 
       it "returns error" do
@@ -80,6 +88,66 @@ RSpec.describe ProceedingTypeService do
                        " where application is made without notice to include representation on the return date.",
         },
       },
+      service_levels: [
+        {
+          level: 3,
+          name: "Full Representation",
+          stage: 8,
+          proceeding_default: true,
+        },
+      ],
+    }
+  end
+
+  def expected_se003_response
+    {
+      success: true,
+      ccms_code: "SE003",
+      meaning: "Prohibited steps order",
+      ccms_category_law_code: "MAT",
+      ccms_matter_code: "KSEC8",
+      name: "prohibited_steps_order_s8",
+      description: "to be represented on an application for a prohibited steps order.",
+      ccms_category_law: "Family",
+      ccms_matter: "Children - section 8",
+      cost_limitations: {
+        substantive: {
+          start_date: "1970-01-01",
+          value: "25000.0",
+        },
+        delegated_functions: {
+          start_date: "2021-09-13",
+          value: "2250.0",
+        },
+      },
+      default_scope_limitations: {
+        substantive: {
+          code: "FM059",
+          meaning: "FHH Children",
+          description: "Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement."\
+                       " To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.",
+        },
+        delegated_functions: {
+          code: "CV117",
+          meaning: "Interim order inc. return date",
+          description: "Limited to all steps necessary to apply for an interim order;"\
+                       " where application is made without notice to include representation on the return date.",
+        },
+      },
+      service_levels: [
+        {
+          level: 3,
+          name: "Full Representation",
+          stage: 8,
+          proceeding_default: false,
+        },
+        {
+          level: 1,
+          name: "Family Help (Higher)",
+          stage: 1,
+          proceeding_default: true,
+        },
+      ],
     }
   end
 end


### PR DESCRIPTION
## What
Expose service levels on proceeding type endpoint

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3078)

To enable consumers to use the associated service
levels per proceeding type.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
