### PR TITLE
Set /api-docs as root route

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -1,0 +1,5 @@
+class MainController < ApplicationController
+  def index
+    redirect_to rswag_ui_path
+  end
+end

--- a/app/services/proceeding_type_service.rb
+++ b/app/services/proceeding_type_service.rb
@@ -59,7 +59,7 @@ private
   end
 
   def add_service_levels_to_response
-    proceeding_type.service_levels.each do |lvl|
+    proceeding_type.service_levels.order(:level).each do |lvl|
       @response[:service_levels] << { level: lvl.level, name: lvl.name, stage: lvl.stage, proceeding_default: lvl.proceeding_default }
     end
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,5 @@ Rails.application.routes.draw do
   root to: "main#index"
 
   get "ping", to: "status#ping", format: :json
+  get "status", to: "status#status", format: :json
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,7 @@ Rails.application.routes.draw do
     resources :searches, only: %i[create]
   end
 
+  root to: "main#index"
+
   get "ping", to: "status#ping", format: :json
 end

--- a/spec/requests/main_spec.rb
+++ b/spec/requests/main_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "MainController", type: :request do
+  describe "GET /" do
+    it "redirects to the api-docs" do
+      get root_path
+      expect(response).to redirect_to("/api-docs")
+    end
+  end
+end

--- a/spec/requests/proceeding_types_spec.rb
+++ b/spec/requests/proceeding_types_spec.rb
@@ -60,16 +60,16 @@ RSpec.describe "ProceedingTypesController", type: :request do
         },
         service_levels: [
           {
-            level: 3,
-            name: "Full Representation",
-            stage: 8,
-            proceeding_default: false,
-          },
-          {
             level: 1,
             name: "Family Help (Higher)",
             stage: 1,
             proceeding_default: true,
+          },
+          {
+            level: 3,
+            name: "Full Representation",
+            stage: 8,
+            proceeding_default: false,
           },
         ],
       }

--- a/spec/requests/status_spec.rb
+++ b/spec/requests/status_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "StatusController", type: :request do
+  describe "GET /satus" do
+    context "when database is available" do
+      let(:expected_response) { { "checks" => { "database" => true } } }
+
+      it "returns ok" do
+        get status_path
+        expect(JSON.parse(response.body)).to eq expected_response
+      end
+    end
+
+    context "when database is down" do
+      let(:expected_response) { { "checks" => { "database" => false } } }
+
+      it "returns false" do
+        allow(ActiveRecord::Base).to receive(:connection).and_raise(PG::ConnectionBad)
+        get status_path
+        expect(JSON.parse(response.body)).to eq expected_response
+      end
+    end
+  end
+
+  describe "GET /ping" do
+    let(:build_date) { Time.zone.now }
+    let(:build_tag) { "app-43ca8c7bfbee8f5fcb96b76baa420c3a45d8a675" }
+    let(:app_branch) { "my-branch" }
+    let(:expected_response) do
+      {
+        build_date:,
+        build_tag:,
+        app_branch:,
+      }
+    end
+
+    before do
+      allow(Rails.configuration.x.status).to receive(:build_date).and_return(build_date)
+      allow(Rails.configuration.x.status).to receive(:build_tag).and_return(build_tag)
+      allow(Rails.configuration.x.status).to receive(:app_branch).and_return(app_branch)
+    end
+
+    it "returns build stats as a JSON body" do
+      get ping_path
+      expect(response.body).to eq expected_response.to_json
+    end
+  end
+end

--- a/spec/services/proceeding_type_service_spec.rb
+++ b/spec/services/proceeding_type_service_spec.rb
@@ -136,16 +136,16 @@ RSpec.describe ProceedingTypeService do
       },
       service_levels: [
         {
-          level: 3,
-          name: "Full Representation",
-          stage: 8,
-          proceeding_default: false,
-        },
-        {
           level: 1,
           name: "Family Help (Higher)",
           stage: 1,
           proceeding_default: true,
+        },
+        {
+          level: 3,
+          name: "Full Representation",
+          stage: 8,
+          proceeding_default: false,
         },
       ],
     }


### PR DESCRIPTION
## Set /api-docs as root route

This originally started as a ticket to set the default root path to `/api-docs`, but other issues became apparent:

- coverage wasn't reporting on files that weren't touched at all during testing
- the ordering of service levels in the response could change from test run to test run leading to flickering tests.

The following changes fix all the above

- set root route as 'main#index`
- create `MainController` with an index action that redirects to `/api-docs`
- set `eager_loading` to `false` for test environment so that `SimpleCov` reports on ALL files, not just the ones that are hit during testing
- Ensure service levels are added to the response in numerical order of service level number
- Change expected results to be in numeric order of service level

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
