### PR TITLE
remove apply prefix before branch name

### DIFF
--- a/bin/delete_dependabot_deployment
+++ b/bin/delete_dependabot_deployment
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 RELEASE_BRANCH=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
-RELEASE_NAME="apply-$RELEASE_BRANCH"
+RELEASE_NAME="$RELEASE_BRANCH"
 echo "Attempting to delete UAT dependabot release on LFA"
 echo "$RELEASE_NAME"
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-2809)
Remove the prefix 'apply-' from the release name as we dont prefix cfe branches

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
