### PR TITLE
[AP-3184] Use remote github action to delete UAT release

### DIFF
--- a/.github/workflows/delete-uat-release.yml
+++ b/.github/workflows/delete-uat-release.yml
@@ -1,0 +1,23 @@
+name: Delete UAT release
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  delete_uat_job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Delete UAT release action
+        id: delete_uat
+        uses: ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.0
+        with:
+          k8s_cluster: ${{ secrets.K8S_GHA_UAT_CLUSTER_NAME }}
+          k8s_cluster_cert: ${{ secrets.K8S_GHA_UAT_CLUSTER_CERT }}
+          k8s_namespace: ${{ secrets.K8S_GHA_UAT_NAMESPACE }}
+          k8s_token: ${{ secrets.K8S_GHA_UAT_TOKEN }}
+      - name: Result
+        shell: bash
+        run: echo ${{ steps.delete_uat.outputs.delete-message }}


### PR DESCRIPTION
## What
[Link to story](https://dsdmoj.atlassian.net/browse/AP-3184)

This uses `ministryofjustice/laa-civil-apply-delete-uat-release@v1.0.0` to allow us to
share the github action logic between all apply service components this.

This will render the circleci step redundant.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
