### PR TITLE
AP-3292: Add the client involvement type api endpoint

### DIFF
--- a/app/controllers/client_involvement_types_controller.rb
+++ b/app/controllers/client_involvement_types_controller.rb
@@ -1,6 +1,6 @@
 class ClientInvolvementTypesController < ApplicationController
   def index
-    result = ClientInvolvementType.all.map { |cit| JSON.parse(cit.api_json) }
-    render json: result.to_json, status: :ok
+    result = ClientInvolvementType.all.map { |cit| cit.api_json }
+    render json: result, status: :ok
   end
 end

--- a/app/controllers/client_involvement_types_controller.rb
+++ b/app/controllers/client_involvement_types_controller.rb
@@ -1,0 +1,6 @@
+class ClientInvolvementTypesController < ApplicationController
+  def index
+    result = ClientInvolvementType.all.map { |cit| JSON.parse(cit.api_json) }
+    render json: result.to_json, status: :ok
+  end
+end

--- a/app/controllers/client_involvement_types_controller.rb
+++ b/app/controllers/client_involvement_types_controller.rb
@@ -1,6 +1,6 @@
 class ClientInvolvementTypesController < ApplicationController
   def index
-    result = ClientInvolvementType.all.map { |cit| cit.api_json }
+    result = ClientInvolvementType.all.map(&:api_json)
     render json: result, status: :ok
   end
 end

--- a/app/models/client_involvement_type.rb
+++ b/app/models/client_involvement_type.rb
@@ -1,2 +1,8 @@
 class ClientInvolvementType < ApplicationRecord
+  def api_json
+    {
+      ccms_code:,
+      description:,
+    }.to_json
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   resources :merits_tasks, param: :ccms_code, only: %i[create]
   get "proceeding_types/all", to: "proceeding_types/searches#index"
+  get "client_involvement_types", to: "client_involvement_types#index"
   resources :proceeding_types, param: :ccms_code, only: %i[show]
   namespace :proceeding_types do
     resources :threshold_waivers, only: %i[create]

--- a/spec/factories/client_involvement_type.rb
+++ b/spec/factories/client_involvement_type.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :client_involvement_type do
+    ccms_code { Faker::Base.resolve(%w[A D I W Z]) }
+    description { Faker::Lorem.sentence(word_count: 4) }
+  end
+end

--- a/spec/models/client_involvement_type_spec.rb
+++ b/spec/models/client_involvement_type_spec.rb
@@ -2,4 +2,12 @@ require "rails_helper"
 
 RSpec.describe ClientInvolvementType, type: :model do
   it { is_expected.to respond_to(:ccms_code, :description) }
+
+  describe ".api_json" do
+    subject(:api_json) { create(:client_involvement_type).api_json }
+
+    it "returns the expected json keys" do
+      expect(JSON.parse(api_json).keys).to match_array(%w[ccms_code description])
+    end
+  end
 end

--- a/spec/requests/client_involvement_types_controller_spec.rb
+++ b/spec/requests/client_involvement_types_controller_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "ClientInvolvementTypesController", type: :request do
+  before { seed_live_data }
+
+  let(:headers) { { "CONTENT_TYPE" => "application/json" } }
+
+  describe "GET client_involvement_types" do
+    subject(:get_request) { get client_involvement_types_path, headers: }
+
+    before { get_request }
+
+    it "returns a successful response with all client_involvement_types" do
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eql("application/json")
+      expect(JSON.parse(response.body).count).to eq 5
+    end
+  end
+end

--- a/spec/requests/swagger_docs/client_involvement_types_spec.rb
+++ b/spec/requests/swagger_docs/client_involvement_types_spec.rb
@@ -1,0 +1,19 @@
+require "swagger_helper"
+
+RSpec.describe "ClientInvolvementTypesController", type: :request, swagger: true do
+  path "/client_involvement_types" do
+    get("Get all client involvement types") do
+      description "Returns an array of all client involvement types with summary data."
+
+      tags "Client involvement types"
+
+      produces "application/json"
+
+      response(200, "successful") do
+        seed_live_data
+        examples "application/json" => ClientInvolvementType.all.map { |cit| JSON.parse(cit.api_json) }
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -4,6 +4,31 @@ info:
   title: API V1
   version: v1
 paths:
+  "/client_involvement_types":
+    get:
+      summary: Get all clientinvolvement types
+      description: |-
+        Returns an array of all proceeding types with summary data.
+                           Call <code>/proceeding_types/XX999</code> where <code>XX999</code> is the ccms_code for more
+                           detailed data on a specific proceeding type.
+      tags:
+      - Client involvement types
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+              - ccms_code: A
+                description: Applicant/claimant/petitioner
+              - ccms_code: D
+                description: Defendant/respondent
+              - ccms_code: W
+                description: Subject of proceedings (child)
+              - ccms_code: Z
+                description: Joined party
+              - ccms_code: I
+                description: Intervenor
   "/merits_tasks":
     post:
       summary: Return details of merits_tasks for specified proceeding types identified


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3292)

Add the new Client Involvement Type endpoint (`/client_involvement_types`)
Update the model to allow the API to return data that is filtered to only the information needed
Add the swagger tests and update the documentation

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
