### PR TITLE
Fix: proceeding_type_defaults swagger

### DIFF
--- a/spec/requests/swagger_docs/proceeding_type_defaults_spec.rb
+++ b/spec/requests/swagger_docs/proceeding_type_defaults_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe "proceeding_type_defaults", type: :request, swagger: true do
                                                   description: "A boolean indicating whether delegated functions were used" },
                       client_involvement_type: { type: :string,
                                                  description: "A code uniquely identifying the client_involvement_type" },
-                      service_level: { type: :integer,
-                                       description: "A code uniquely identifying the service_level" },
+                      level_of_service_code: { type: :integer,
+                                               description: "A code uniquely identifying the service_level" },
                     },
                     required: %w[proceeding_type_ccms_code delegated_functions_used client_involvement_type service_level],
                   }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -211,7 +211,7 @@ paths:
                 client_involvement_type:
                   type: string
                   description: A code uniquely identifying the client_involvement_type
-                service_level:
+                level_of_service_code:
                   type: integer
                   description: A code uniquely identifying the service_level
               required:


### PR DESCRIPTION
## What

One of the variables was mis-named in the example

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
