### PR TITLE
AP-3381 Add Scope user Inputs table

### DIFF
--- a/app/models/scope_limitation.rb
+++ b/app/models/scope_limitation.rb
@@ -1,6 +1,11 @@
 class ScopeLimitation < ApplicationRecord
   has_many :proceeding_type_scope_limitations, dependent: :destroy
   has_many :proceeding_types, through: :proceeding_type_scope_limitations
+  has_many :scope_limitation_user_inputs
+  has_many :user_inputs,
+           source: :scope_user_input,
+           through: :scope_limitation_user_inputs,
+           class_name: "ScopeUserInput"
 
   def self.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
     codes = ProceedingTypeScope.where(proceeding_type_ccms_code: pt_ccms_code,

--- a/app/models/scope_limitation_user_input.rb
+++ b/app/models/scope_limitation_user_input.rb
@@ -1,0 +1,4 @@
+class ScopeLimitationUserInput < ApplicationRecord
+  belongs_to :scope_limitation
+  belongs_to :scope_user_input
+end

--- a/app/models/scope_user_input.rb
+++ b/app/models/scope_user_input.rb
@@ -1,0 +1,3 @@
+class ScopeUserInput < ApplicationRecord
+  validates :input_type, inclusion: { in: %w[date text], message: "%{value} is not a valid input_type" }
+end

--- a/db/migrate/20220804111406_create_scope_user_inputs.rb
+++ b/db/migrate/20220804111406_create_scope_user_inputs.rb
@@ -1,0 +1,13 @@
+class CreateScopeUserInputs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :scope_user_inputs, id: :uuid do |t|
+      t.text :input_name, null: false
+      t.text :input_type, null: false
+      t.boolean :mandatory, null: false, default: true
+
+      t.timestamps
+    end
+
+    add_index :scope_user_inputs, :input_name, unique: true
+  end
+end

--- a/db/migrate/20220804112224_create_scope_limitation_user_inputs.rb
+++ b/db/migrate/20220804112224_create_scope_limitation_user_inputs.rb
@@ -1,0 +1,10 @@
+class CreateScopeLimitationUserInputs < ActiveRecord::Migration[7.0]
+  def change
+    create_table :scope_limitation_user_inputs do |t|
+      t.references :scope_limitation, type: :uuid
+      t.references :scope_user_input, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_28_101235) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_04_112224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -124,6 +124,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_28_101235) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "scope_limitation_user_inputs", force: :cascade do |t|
+    t.uuid "scope_limitation_id"
+    t.uuid "scope_user_input_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["scope_limitation_id"], name: "index_scope_limitation_user_inputs_on_scope_limitation_id"
+    t.index ["scope_user_input_id"], name: "index_scope_limitation_user_inputs_on_scope_user_input_id"
+  end
+
   create_table "scope_limitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "code", null: false
     t.string "meaning", null: false
@@ -133,6 +142,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_28_101235) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_scope_limitations_on_code"
+  end
+
+  create_table "scope_user_inputs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "input_name", null: false
+    t.text "input_type", null: false
+    t.boolean "mandatory", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["input_name"], name: "index_scope_user_inputs_on_input_name", unique: true
   end
 
   create_table "service_levels", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/scope_limitations.rb
+++ b/spec/factories/scope_limitations.rb
@@ -13,5 +13,17 @@ FactoryBot.define do
       substantive { true }
       delegated_functions { true }
     end
+
+    trait :with_hearing_date do
+      after(:create) do |rec|
+        rec.user_inputs << create(:scope_user_input, :hearing_date)
+      end
+    end
+
+    trait :with_opponent_name do
+      after(:create) do |rec|
+        rec.user_inputs << create(:scope_user_input, :opponent_name)
+      end
+    end
   end
 end

--- a/spec/factories/scope_user_inputs.rb
+++ b/spec/factories/scope_user_inputs.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :scope_user_input do
+    input_name { "MyText" }
+    input_type { "MyText" }
+    mandatory { false }
+
+    trait :hearing_date do
+      input_name { "hearing_date" }
+      input_type { "date" }
+      mandatory { true }
+    end
+
+    trait :opponent_name do
+      input_name { "opponent_name" }
+      input_type { "text" }
+      mandatory { true }
+    end
+  end
+end

--- a/spec/models/scope_limitation_spec.rb
+++ b/spec/models/scope_limitation_spec.rb
@@ -129,13 +129,13 @@ RSpec.describe ScopeLimitation do
     let(:opponent_name) { create :scope_user_input, :opponent_name }
     let(:scope) { create :scope_limitation }
 
-    context "adding new user inputs" do
+    context "when adding new user inputs" do
       it "creates a record in the join table" do
-        expect { scope.user_inputs << hearing_date }.to change { ScopeLimitationUserInput.count }.by(1)
+        expect { scope.user_inputs << hearing_date }.to change(ScopeLimitationUserInput, :count).by(1)
       end
     end
 
-    context "retrieving user inputs" do
+    context "when retrieving user inputs" do
       before do
         scope.user_inputs << hearing_date
         scope.user_inputs << opponent_name

--- a/spec/models/scope_limitation_spec.rb
+++ b/spec/models/scope_limitation_spec.rb
@@ -124,6 +124,29 @@ RSpec.describe ScopeLimitation do
     end
   end
 
+  describe "user_inputs" do
+    let(:hearing_date) { create :scope_user_input, :hearing_date }
+    let(:opponent_name) { create :scope_user_input, :opponent_name }
+    let(:scope) { create :scope_limitation }
+
+    context "adding new user inputs" do
+      it "creates a record in the join table" do
+        expect { scope.user_inputs << hearing_date }.to change { ScopeLimitationUserInput.count }.by(1)
+      end
+    end
+
+    context "retrieving user inputs" do
+      before do
+        scope.user_inputs << hearing_date
+        scope.user_inputs << opponent_name
+      end
+
+      it "returns both user input records" do
+        expect(scope.user_inputs).to match_array [hearing_date, opponent_name]
+      end
+    end
+  end
+
   def populate_seed_data
     MatterTypePopulator.call
     ProceedingType.populate

--- a/spec/models/scope_user_input_spec.rb
+++ b/spec/models/scope_user_input_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ScopeUserInput, type: :model do
+  describe 'validations' do
+    let(:user_input) { build :scope_user_input, input_name: "my input", input_type: input_type, mandatory: true }
+
+    describe 'input_type' do
+      context 'with valid value of date' do
+        let(:input_type) { "date" }
+        it 'is valid' do
+          expect(user_input).to be_valid
+        end
+      end
+
+      context 'with valid value of date' do
+        let(:input_type) { "text" }
+        it 'is valid' do
+          expect(user_input).to be_valid
+        end
+      end
+
+      context 'with invalid input type' do
+        let(:input_type) { 'boolean' }
+        it 'is not valid' do
+          expect(user_input).not_to be_valid
+          expect(user_input.errors[:input_type]).to eq ['boolean is not a valid input_type']
+        end
+      end
+    end
+  end
+
+end

--- a/spec/models/scope_user_input_spec.rb
+++ b/spec/models/scope_user_input_spec.rb
@@ -1,32 +1,34 @@
 require "rails_helper"
 
 RSpec.describe ScopeUserInput, type: :model do
-  describe 'validations' do
-    let(:user_input) { build :scope_user_input, input_name: "my input", input_type: input_type, mandatory: true }
+  describe "validations" do
+    let(:user_input) { build :scope_user_input, input_name: "my input", input_type:, mandatory: true }
 
-    describe 'input_type' do
-      context 'with valid value of date' do
+    describe "input_type" do
+      context "with valid value of date" do
         let(:input_type) { "date" }
-        it 'is valid' do
+
+        it "is valid" do
           expect(user_input).to be_valid
         end
       end
 
-      context 'with valid value of date' do
+      context "with valid value of text" do
         let(:input_type) { "text" }
-        it 'is valid' do
+
+        it "is valid" do
           expect(user_input).to be_valid
         end
       end
 
-      context 'with invalid input type' do
-        let(:input_type) { 'boolean' }
-        it 'is not valid' do
+      context "with invalid input type" do
+        let(:input_type) { "boolean" }
+
+        it "is not valid" do
           expect(user_input).not_to be_valid
-          expect(user_input.errors[:input_type]).to eq ['boolean is not a valid input_type']
+          expect(user_input.errors[:input_type]).to eq ["boolean is not a valid input_type"]
         end
       end
     end
   end
-
 end


### PR DESCRIPTION
## Add Scope user Inputs table

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3381)

Some scope limitations have user input requirements.  This PR creates a table of user inputs definitaions, defining the name, the type of input and whether or not it is mandatory, and a many-to-many join table between scope and user inputs

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
