### PR TITLE
AP-3372 ProceedingTypeScopes join table populator

### DIFF
--- a/app/models/client_involvement_type.rb
+++ b/app/models/client_involvement_type.rb
@@ -1,4 +1,8 @@
 class ClientInvolvementType < ApplicationRecord
+  VALID_CLIENT_INVOLVEMENT_TYPES = %w[A D I W Z].freeze
+
+  validates :ccms_code, inclusion: { in: VALID_CLIENT_INVOLVEMENT_TYPES, message: "%{value} is not a valid client_involvement_type" }
+
   def api_json
     {
       ccms_code:,

--- a/db/seed_data/proceeding_type_scopes.yml
+++ b/db/seed_data/proceeding_type_scopes.yml
@@ -1,193 +1,163 @@
 ---
-proceeding_types:
-  - proceeding_type_code: SE013
-    service_levels:
-      - level_num: 1
-        scopes:
-          - CV027
-          - CV079
-          - CV117
-          - CV118
-          - FM004
-          - FM007
-          - FM015
-          - FM019
-          - FM059
-        defaults:
-          substantive:
-            cit_a: FM059
-            cit_diwz: FM059
-          df_used:
-            cit_a: CV117
-            cit_diwz: CV118
-      - level_num: 3
-        scopes:
-          - CV027
-          - CV117
-          - CV118
-          - FM007
-          - FM019
-          - FM039
-          - FM049
-        defaults:
-          substantive:
-            cit_a: FM049
-            cit_diwz: FM049
-          df_used:
-            cit_a: CV117
-            cit_diwz: CV118
-  - proceeding_type_code: SE014
-    service_levels:
-      - level_num: 1
-        scopes:
-          - CV027
-          - CV079
-          - CV117
-          - CV118
-          - FM004
-          - FM007
-          - FM015
-          - FM019
-          - FM059
-        defaults:
-          substantive:
-            cit_a: FM059
-            cit_diwz: FM059
-          df_used:
-            cit_a: CV117
-            cit_diwz: CV118
-      - level_num: 3
-        scopes:
-          - CV027
-          - CV117
-          - CV118
-          - FM007
-          - FM019
-          - FM039
-          - FM049
-        defaults:
-          substantive:
-            cit_a: FM049
-            cit_diwz: FM049
-          df_used:
-            cit_a: CV117
-            cit_diwz: CV118
-#
-#
-#
-# The seed data for SE015 below is commented out for now. The seeded proceeding_types table does not contain a record for SE015,
-# and we can't add the join record in this table until it exists.
-# We can't simply add the SE015 Proceeding type yet (it is one of the proceeding types that will be introduced with full section 8) until there is a mechanism in
-# Apply for ignoring full section 8 proceedings for un-enabled providers.
-#
-#
-#
-#
-#  - proceeding_type_code: SE015
-#    service_levels:
-#      - level_num: 1
-#        scopes:
-#          - CV027
-#          - CV079
-#          - CV117
-#          - CV118
-#          - FM004
-#          - FM007
-#          - FM015
-#          - FM019
-#          - FM059
-#        defaults:
-#          substantive:
-#            cit_a: FM059
-#            cit_diwz: FM059
-#          df_used:
-#            cit_a: CV117
-#            cit_diwz: CV118
-#      - level_num: 3
-#        scopes:
-#          - CV027
-#          - CV117
-#          - CV118
-#          - FM007
-#          - FM019
-#          - FM039
-#          - FM049
-#        defaults:
-#          substantive:
-#            cit_a: FM049
-#            cit_diwz: FM049
-#          df_used:
-#            cit_a: CV117
-#            cit_diwz: CV118
-  - proceeding_type_code: SE003
-    service_levels:
-      - level_num: 1
-        scopes:
-          - CV027
-          - CV079
-          - CV117
-          - CV118
-          - FM004
-          - FM007
-          - FM015
-          - FM019
-          - FM059
-        defaults:
-          substantive:
-            cit_a: FM059
-            cit_diwz: FM059
-          df_used:
-            cit_a: CV117
-            cit_diwz: CV118
-      - level_num: 3
-        scopes:
-          - CV027
-          - CV117
-          - CV118
-          - FM007
-          - FM019
-          - FM039
-          - FM049
-        defaults:
-          substantive:
-            cit_a: FM049
-            cit_diwz: FM049
-          df_used:
-            cit_a: CV117
-            cit_diwz: CV118
-  - proceeding_type_code: SE004
-    service_levels:
-      - level_num: 1
-        scopes:
-          - CV027
-          - CV079
-          - CV117
-          - CV118
-          - FM004
-          - FM007
-          - FM015
-          - FM019
-          - FM059
-        defaults:
-          substantive:
-            cit_a: FM059
-            cit_diwz: FM059
-          df_used:
-            cit_a: CV117
-            cit_diwz: CV118
-      - level_num: 3
-        scopes:
-          - CV027
-          - CV117
-          - CV118
-          - FM007
-          - FM019
-          - FM039
-          - FM049
-        defaults:
-          substantive:
-            cit_a: FM049
-            cit_diwz: FM049
-          df_used:
-            cit_a: CV117
-            cit_diwz: CV118
+:section_8_base:
+  :proceeding_types:
+    - SE003
+    - SE004
+    - SE007
+    - SE008
+    - SE013
+    - SE014
+    - SE015
+    - SE016
+    - SE095
+    - SE097
+  :service_levels:
+    - :level: 1
+      :scopes:
+        - CV027
+        - CV079
+        - CV117
+        - CV118
+        - FM004
+        - FM007
+        - FM015
+        - FM019
+        - FM059
+      :defaults:
+        :substantive:
+          :cit_a: FM059
+          :cit_not_a: FM059
+        :delegated_functions:
+          :cit_a: CV117
+          :cit_not_a: CV118
+    - :level: 3
+      :scopes:
+        - CV027
+        - CV117
+        - CV118
+        - FM007
+        - FM019
+        - FM039
+        - FM049
+      :defaults:
+        :substantive:
+          :cit_a: FM049
+          :cit_not_a: FM049
+        :delegated_functions:
+          :cit_a: CV117
+          :cit_not_a: CV118
+:section_8_appeals:
+  :proceeding_types:
+    - SE003A
+    - SE004A
+    - SE007A
+    - SE008A
+    - SE013A
+    - SE014A
+    - SE015A
+    - SE016A
+    - SE095A
+    - SE097A
+    - SE101A
+  :service_levels:
+    - :level: 3
+      :scopes:
+        - APL09
+        - APL07
+        - APL11
+        - APL13
+        - APL15
+        - APL16
+        - APL18
+        - APL20
+        - APL22
+        - APL27
+        - APL29
+        - APL31
+        - APL48
+        - APL49
+        - APL50
+        - APL51
+        - APL52
+        - APL53
+        - APL54
+        - APL55
+        - APL56
+        - APL57
+        - APL65
+        - APL66
+        - APL67
+        - APL68
+        - APL69
+        - APL70
+        - CV027
+        - CV079
+        - CV118
+      :defaults:
+        :substantive:
+          :cit_a: CV079
+          :cit_not_a: CV079
+        :delegated_functions:
+          :cit_a: CV118
+          :cit_not_a: CV118
+:section_8_enforcements:
+  :proceeding_types:
+    - SE003E
+    - SE004E
+    - SE007E
+    - SE008E
+    - SE013E
+    - SE014E
+    - SE015E
+    - SE016E
+    - SE096E
+    - SE099E
+    - SE100E
+    - SE101E
+  :service_levels:
+    - :level: 3
+      :scopes:
+        - CV027
+        - CV118
+        - EF012
+        - EF022
+        - EF025
+        - EF026
+        - EF027
+        - FM019
+        - FM049
+        - MC029
+      :defaults:
+        :substantive:
+          :cit_a: FM019
+          :cit_not_a: FM019
+        :delegated_functions:
+          :cit_a: FM019
+          :cit_not_a: FM019
+:domestic_abuse:
+  :proceeding_types:
+    - DA001
+    - DA002
+    - DA003
+    - DA004
+    - DA005
+    - DA006
+    - DA007
+    - DA020
+  :service_levels:
+    - :level: 3
+      :scopes:
+        - AA009
+        - AA019
+        - CV027
+        - CV079
+        - CV117
+        - CV118
+        - FM054
+      :defaults:
+        :substantive:
+          :cit_a: AA019
+          :cit_not_a: AA019
+        :delegated_functions:
+          :cit_a: CV117
+          :cit_not_a: CV118

--- a/spec/models/client_involvement_type_spec.rb
+++ b/spec/models/client_involvement_type_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe ClientInvolvementType, type: :model do
   it { is_expected.to respond_to(:ccms_code, :description, :ordering) }
 
+  it { is_expected.to validate_inclusion_of(:ccms_code).in_array(described_class::VALID_CLIENT_INVOLVEMENT_TYPES).with_message(/is not a valid client_involvement_type/) }
+
   describe ".api_json" do
     subject(:api_json) { create(:client_involvement_type).api_json }
 

--- a/spec/models/scope_limitation_spec.rb
+++ b/spec/models/scope_limitation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ScopeLimitation do
 
     context "with service level 1" do
       it "returns all the correct scope limitation records" do
-        expected_codes = %w[CV027 CV079 CV117 CV118 FM004 FM007 FM015 FM019 FM059]
+        expected_codes = %w[CV027 CV079 CV117 CV118 FM004 FM007 FM015 FM019]
         expect(actual_codes).to match_array(expected_codes)
       end
     end

--- a/spec/populators/proceeding_type_scope_populator_spec.rb
+++ b/spec/populators/proceeding_type_scope_populator_spec.rb
@@ -1,0 +1,253 @@
+require "rails_helper"
+
+RSpec.describe ProceedingTypeScopePopulator do
+  describe "records are properly populated" do
+    describe "section 8 base" do
+      let(:pt_ccms_code) { %w[SE003 SE004 SE007 SE008 SE013 SE014 SE015 SE016 SE095 SE097].sample }
+      let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
+      let(:client_involvement_type_not_a) { %w[D I W Z].sample }
+
+      context "with service level 1 substantive" do
+        let(:service_level) { 1 }
+        let(:df_used) { false }
+        let(:expected_scopes) { %w[CV027 CV079 CV117 CV118 FM004 FM007 FM015 FM019 FM059] }
+
+        it "returns expected eligible scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        it "returns the expected default scope" do
+          scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_record.code).to eq "FM059"
+        end
+      end
+
+      context "with service level 1 delegated functions" do
+        let(:service_level) { 1 }
+        let(:df_used) { true }
+        let(:expected_scopes) { %w[CV027 CV079 CV117 CV118 FM004 FM007 FM015 FM019] }
+
+        it "returns the expected scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "CV117"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "CV118"
+          end
+        end
+      end
+
+      context "with service level 3 substantive" do
+        let(:service_level) { 3 }
+        let(:df_used) { false }
+        let(:expected_scopes) { %w[CV027 CV117 CV118 FM007 FM019 FM039 FM049] }
+
+        it "returns expected eligible scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        it "returns the expected default scope" do
+          scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_record.code).to eq "FM049"
+        end
+      end
+
+      context "with service level 3 delegated functions" do
+        let(:service_level) { 3 }
+        let(:df_used) { true }
+        let(:expected_scopes) { %w[CV027 CV117 CV118 FM007 FM019 FM039 FM049] }
+
+        it "returns the expected scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "CV117"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "CV118"
+          end
+        end
+      end
+    end
+
+    describe "section 8 appeals" do
+      let(:pt_ccms_code) { %w[SE003A SE004A SE007A SE008A SE013A SE014A SE015A SE016A SE095A SE097A SE101A].sample }
+      let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
+      let(:client_involvement_type_not_a) { %w[D I W Z].sample }
+
+      context "with service level 3 substantive" do
+        let(:service_level) { 3 }
+        let(:df_used) { false }
+        let(:expected_scopes) { %w[APL07 APL09 APL11 APL13 APL15 APL16 APL18 APL20 APL22 APL27 APL29 APL31 APL48 APL49 APL50 APL51 APL52 APL53 APL54 APL55 APL56 APL57 APL65 APL66 APL67 APL68 APL69 APL70 CV027 CV079 CV118] }
+
+        it "returns expected eligible scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        it "returns the expected default scope" do
+          scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_record.code).to eq "CV079"
+        end
+      end
+
+      context "with service level 3 delegated functions" do
+        let(:service_level) { 3 }
+        let(:df_used) { true }
+        let(:expected_scopes) { %w[APL07 APL09 APL11 APL13 APL15 APL16 APL18 APL20 APL22 APL27 APL29 APL31 APL48 APL49 APL50 APL51 APL52 APL53 APL54 APL55 APL56 APL57 APL65 APL66 APL67 APL68 APL69 APL70 CV027 CV079 CV118] }
+
+        it "returns the expected scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "CV118"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "CV118"
+          end
+        end
+      end
+    end
+
+    describe "section 8 enforcements" do
+      let(:pt_ccms_code) { %w[SE003E SE004E SE007E SE008E SE013E SE014E SE015E SE016E SE096E SE099E SE100E SE101E].sample }
+      let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
+      let(:client_involvement_type_not_a) { %w[D I W Z].sample }
+      let(:expected_scopes) { %w[CV027 CV118 EF012 EF022 EF025 EF026 EF027 FM019 FM049 MC029] }
+
+      context "with service level 3 substantive" do
+        let(:service_level) { 3 }
+        let(:df_used) { false }
+
+        it "returns expected eligible scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        it "returns the expected default scope" do
+          scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_record.code).to eq "FM019"
+        end
+      end
+
+      context "with service level 3 delegated functions" do
+        let(:service_level) { 3 }
+        let(:df_used) { true }
+
+        it "returns the expected scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "FM019"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "FM019"
+          end
+        end
+      end
+    end
+
+    describe "domestic abuse" do
+      let(:pt_ccms_code) { %w[DA001 DA002 DA003 DA004 DA005 DA006 DA007 DA020].sample }
+      let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
+      let(:client_involvement_type_not_a) { %w[D I W Z].sample }
+
+      context "with service level 3 substantive" do
+        let(:service_level) { 3 }
+        let(:df_used) { false }
+        let(:expected_scopes) { %w[AA009 AA019 CV027 CV079 CV117 CV118 FM054] }
+
+        it "returns expected eligible scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        it "returns the expected default scope" do
+          scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_record.code).to eq "AA019"
+        end
+      end
+
+      context "with service level 3 delegated functions" do
+        let(:service_level) { 3 }
+        let(:df_used) { true }
+        let(:expected_scopes) { %w[AA009 CV027 CV079 CV117 CV118 FM054] }
+
+        it "returns the expected scopes" do
+          scope_records = ScopeLimitation.eligible_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope_records.map(&:code)).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "CV117"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope_record = ScopeLimitation.default_for(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope_record.code).to eq "CV118"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## ProceedingTypeScopes join table populator

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3372)

now that the structure of proceedfing types and scopes has been finalised, this PR re-writes the YAML seed file and the populator to read it and write the join records, with extensive testing to ensure no errors have been made in seeding this table.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
