### PR TITLE
Ap 3351 proceeding type scopes endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ gem "puma", "~> 5.6"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false
 
+gem "json-schema", "~> 2.8.1"
+
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem "rack-cors"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,7 @@ DEPENDENCIES
   faker (>= 1.9.1)
   guard-rubocop
   highline
+  json-schema (~> 2.8.1)
   json_expressions
   listen (~> 3.7)
   net-imap

--- a/app/controllers/proceeding_type_scopes_controller.rb
+++ b/app/controllers/proceeding_type_scopes_controller.rb
@@ -1,0 +1,7 @@
+class ProceedingTypeScopesController < ApplicationController
+  def create
+    response = ProceedingTypeScopesService.call(proceeding_type_scopes_params: request.raw_post)
+    status = response[:success] ? 200 : 400
+    render json: response, status:
+  end
+end

--- a/app/services/proceeding_type_scopes_service.rb
+++ b/app/services/proceeding_type_scopes_service.rb
@@ -1,0 +1,76 @@
+class ProceedingTypeScopesService
+  def self.call(proceeding_type_scopes_params:)
+    new(proceeding_type_scopes_params).call
+  end
+
+  def initialize(proceeding_type_scopes_params)
+    @proceeding_type_scopes_params = proceeding_type_scopes_params
+    @errors = []
+  end
+
+  def call
+    if json_validator.valid?
+      @response = create_skeleton_response
+      add_level_of_service_to_response
+    else
+      @response = error_response
+      @errors.concat(json_validator.errors)
+    end
+    @response
+  end
+
+private
+
+  def create_skeleton_response
+    {
+      success: true,
+      requested_params: {
+        proceeding_type_ccms_code:,
+        delegated_functions_used:,
+        client_involvement_type:,
+        level_of_service_code:,
+      },
+    }
+  end
+
+  def add_level_of_service_to_response
+    sl = ServiceLevel.find_by!(level: level_of_service_code)
+    @response[:level_of_service] = { level: sl.level, name: sl.name, stage: sl.stage, scope_limitations: }
+  end
+
+  def scope_limitations
+    scope_limitations = []
+    scopes = ScopeLimitation.eligible_for(proceeding_type_ccms_code, client_involvement_type, level_of_service_code, delegated_functions_used).order(:meaning)
+    scopes.each do |scope|
+      scope_limitations << { code: scope.code, meaning: scope.meaning, description: scope.description, additional_params: [] }
+    end
+    scope_limitations
+  end
+
+  def proceeding_type_ccms_code
+    @proceeding_type_ccms_code ||= JSON.parse(@proceeding_type_scopes_params, symbolize_names: true)[:proceeding_type_ccms_code]
+  end
+
+  def delegated_functions_used
+    @delegated_functions_used ||= JSON.parse(@proceeding_type_scopes_params, symbolize_names: true)[:delegated_functions_used]
+  end
+
+  def client_involvement_type
+    @client_involvement_type ||= JSON.parse(@proceeding_type_scopes_params, symbolize_names: true)[:client_involvement_type]
+  end
+
+  def level_of_service_code
+    @level_of_service_code ||= JSON.parse(@proceeding_type_scopes_params, symbolize_names: true)[:level_of_service_code]
+  end
+
+  def error_response
+    {
+      success: false,
+      errors: @errors,
+    }
+  end
+
+  def json_validator
+    @json_validator ||= JsonValidator.new("proceeding_type_scopes", @proceeding_type_scopes_params)
+  end
+end

--- a/app/validators/json_validator.rb
+++ b/app/validators/json_validator.rb
@@ -1,0 +1,31 @@
+class JsonValidator
+  def initialize(schema_name, payload)
+    @schema_name = schema_name
+    @payload = payload
+  end
+
+  def valid?
+    JSON::Validator.validate(schema, @payload)
+  end
+
+  def errors
+    JSON::Validator.fully_validate(schema, @payload)
+  end
+
+private
+
+  attr_reader :schema_name
+
+  def schema
+    @schema ||= load_schema
+  end
+
+  def load_schema
+    filename = "#{schema_dir}/#{schema_name}.json.erb"
+    ERB.new(File.read(filename)).result(binding)
+  end
+
+  def schema_dir
+    @schema_dir ||= Rails.root.join("public/schemas")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   end
   resources :threshold_waivers, only: %i[create]
   resources :proceeding_type_defaults, only: %i[create]
+  resources :proceeding_type_scopes, only: %i[create]
 
   root to: "main#index"
 

--- a/public/schemas/proceeding_type_scopes.json.erb
+++ b/public/schemas/proceeding_type_scopes.json.erb
@@ -1,0 +1,21 @@
+{
+  "id": "file://#{@schema_dir}/proceeding_type_scopes.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legal Framework Api proceeding_type_scopes schema",
+  "type": "object",
+  "required": ["proceeding_type_ccms_code", "delegated_functions_used", "client_involvement_type", "level_of_service_code"],
+  "properties": {
+    "proceeding_type_ccms_code": {
+      "enum": <%= ProceedingType.pluck(:ccms_code).as_json %>
+    },
+    "delegated_functions_used": {
+      "type": "boolean"
+    },
+    "client_involvement_type": {
+      "enum": <%= ClientInvolvementType.pluck(:ccms_code).as_json %>
+    },
+    "level_of_service_code": {
+      "enum": <%= ServiceLevel.pluck(:level).as_json %>
+    }
+  }
+}

--- a/spec/requests/proceeding_type_defaults_controller_spec.rb
+++ b/spec/requests/proceeding_type_defaults_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "ProceedingTypeDefaultsController", type: :request do
-  describe "POST threshold_waivers" do
+  describe "POST proceeding_type_defaults" do
     subject(:proceeding_type_defaults_post_request) { post proceeding_type_defaults_path, params: params.to_json, headers: }
 
     let(:request_id) { SecureRandom.uuid }

--- a/spec/requests/proceeding_type_scopes_controller_spec.rb
+++ b/spec/requests/proceeding_type_scopes_controller_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe "ProceedingTypeScopesController", type: :request do
+  describe "POST proceeding type scopes" do
+    subject(:proceeding_type_scopes_request) { post proceeding_type_scopes_path, params: params.to_json, headers: }
+
+    let(:request_id) { SecureRandom.uuid }
+    let(:headers) { { "CONTENT_TYPE" => "application/json" } }
+    let(:params) do
+      {
+        proceeding_type_ccms_code: "SE013",
+        delegated_functions_used: false,
+        client_involvement_type: "A",
+        level_of_service_code: 1,
+      }
+    end
+
+    context "when the request is successful" do
+      it "returns success" do
+        proceeding_type_scopes_request
+        expect(response).to have_http_status(:success)
+      end
+
+      it "returns the expected response" do
+        proceeding_type_scopes_request
+        expect(JSON.parse(response.body)).to match expected_successful_response
+      end
+    end
+
+    context "when the request is unsuccessful" do
+      let(:params) do
+        {
+          proceeding_type_ccms_code: "XX123",
+          delegated_functions_used: false,
+          client_involvement_type: "A",
+          level_of_service_code: 1,
+        }
+      end
+
+      it "returns bad request" do
+        proceeding_type_scopes_request
+        expect(response.status).to eq 400
+      end
+
+      it "returns expected error response" do
+        proceeding_type_scopes_request
+        expect(parsed_response[:success]).to be false
+        expect(parsed_response[:errors]).to match [/The property '#\/proceeding_type_ccms_code' value "XX123" did not match one of the following values: .* in schema file/]
+      end
+    end
+
+    def expected_successful_response
+      {
+        success: true,
+        requested_params: {
+          proceeding_type_ccms_code: "SE013",
+          delegated_functions_used: false,
+          client_involvement_type: "A",
+          level_of_service_code: 1,
+        },
+        level_of_service: {
+          level: 1,
+          name: "Family Help (Higher)",
+          stage: 1,
+          scope_limitations: [
+            {
+              code: "FM007",
+              meaning: "Blood Tests or DNA Tests",
+              description: "Limited to all steps up to and including the obtaining of blood tests or DNA tests and thereafter a solicitor's report.",
+              additional_params: [],
+            },
+            {
+              code: "FM004",
+              meaning: "CAFCASS report",
+              description: "Limited to all steps up to and including the Children and Family Reporter's Report and thereafter a solicitor's report.",
+              additional_params: [],
+            },
+            {
+              code: "CV079",
+              meaning: "Counsel's Opinion",
+              description: "Limited to obtaining external Counsel's Opinion or the opinion of an external solicitor with higher court advocacy rights on the information already available.",
+              additional_params: [],
+            },
+            {
+              code: "FM019",
+              meaning: "Exchange of Evidence",
+              description: "Limited to all steps up to and including the exchange of evidence (including any welfare officer's/guardian ad litem's report) and directions appointments but not including a final contested hearing and thereafter to a solicitors report (or if so advised a Counsel's opinion) on the issues and prospects of success.",
+              additional_params: [],
+            },
+            {
+              code: "FM059",
+              meaning: "FHH Children",
+              description: "Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement. To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.",
+              additional_params: [],
+            },
+            {
+              code: "CV118",
+              meaning: "Hearing",
+              description: "Limited to all steps up to and including the hearing on [see additional limitation notes]",
+              additional_params: [],
+            },
+            {
+              code: "CV027",
+              meaning: "Hearing/Adjournment",
+              description: "Limited to all steps (including any adjournment thereof) up to and including the hearing on",
+              additional_params: [],
+            },
+            {
+              code: "CV117",
+              meaning: "Interim order inc. return date",
+              description: "Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date.",
+              additional_params: [],
+            },
+            {
+              code: "FM015",
+              meaning: "Section 37 Report",
+              description: "Limited to a section 37 report only.",
+              additional_params: [],
+            },
+          ],
+        },
+      }.as_json
+    end
+  end
+end

--- a/spec/requests/swagger_docs/proceeding_type_scopes_spec.rb
+++ b/spec/requests/swagger_docs/proceeding_type_scopes_spec.rb
@@ -1,0 +1,43 @@
+require "swagger_helper"
+
+RSpec.describe "proceeding_type_scopes", type: :request, swagger: true do
+  path "/proceeding_type_scopes" do
+    post("Return details of level_of_service and scope_limitations for specified proceeding_type_ccms_code, delegated_functions_used, client_involvement_type and level_of_service_code") do
+      description "POST a JSON payload containing a proceeding_type_ccms_code, boolean whether delegated_functions_used, client_involvement_type and level_of_service_code
+                  to recieve a payload containing the same request params, and level_of_service and associated scope_limitations."
+
+      proceeding_type_ccms_code = "SE004"
+      delegated_functions_used = false
+      client_involvement_type = "A"
+      level_of_service_code = 1
+
+      tags "Proceeding type service level"
+      response(200, "successful") do
+        consumes "application/json"
+        produces "application/json"
+        parameter name: "proceeding_type_scopes_query",
+                  in: :body,
+                  schema: {
+                    type: :object,
+                    properties: {
+                      proceeding_type_ccms_code: { type: :string,
+                                                   description: "A code uniquely identifying the proceeding_type" },
+                      delegated_functions_used: { type: :boolean,
+                                                  description: "A boolean indicating whether delegated functions were used" },
+                      client_involvement_type: { type: :string,
+                                                 description: "A code uniquely identifying the client_involvement_type" },
+                      level_of_service_code: { type: :integer,
+                                               description: "A code uniquely identifying the service_level" },
+                    },
+                    required: %w[proceeding_type_ccms_code delegated_functions_used client_involvement_type service_level],
+                  }
+        response(200, "success") do
+          response = ProceedingTypeScopesService.call(proceeding_type_scopes_params: { proceeding_type_ccms_code:, delegated_functions_used:, client_involvement_type:, level_of_service_code: }.to_json)
+
+          examples "application/json" => response
+          run_test!
+        end
+      end
+    end
+  end
+end

--- a/spec/services/proceeding_type_scopes_service_spec.rb
+++ b/spec/services/proceeding_type_scopes_service_spec.rb
@@ -1,0 +1,109 @@
+require "rails_helper"
+
+RSpec.describe ProceedingTypeScopesService do
+  subject(:proceeding_type_scopes_response) { described_class.call(proceeding_type_scopes_params:) }
+
+  let(:proceeding_type_scopes_params) do
+    {
+      proceeding_type_ccms_code:,
+      delegated_functions_used:,
+      client_involvement_type:,
+      level_of_service_code:,
+    }.to_json
+  end
+  let(:proceeding_type_ccms_code) { "SE003" }
+  let(:delegated_functions_used) { false }
+  let(:client_involvement_type) { "D" }
+  let(:level_of_service_code) { 1 }
+
+  context "when the request is successful" do
+    it "returns valid response with expected defaults" do
+      expect(proceeding_type_scopes_response).to eq expected_successful_response
+    end
+  end
+
+  context "when the request is unsuccessful" do
+    context "with a non_existent client_involvement_type" do
+      let(:level_of_service_code) { 7 }
+
+      it "returns error" do
+        response = proceeding_type_scopes_response
+        expect(response[:success]).to be false
+        expect(response[:errors]).to match [/The property '#\/level_of_service_code' value 7 did not match one of the following values: .* in schema file/]
+      end
+    end
+  end
+
+  def expected_successful_response
+    {
+      success: true,
+      requested_params: {
+        proceeding_type_ccms_code: "SE003",
+        delegated_functions_used: false,
+        client_involvement_type: "D",
+        level_of_service_code: 1,
+      },
+      level_of_service: {
+        level: 1,
+        name: "Family Help (Higher)",
+        stage: 1,
+        scope_limitations: [
+          {
+            code: "FM007",
+            meaning: "Blood Tests or DNA Tests",
+            description: "Limited to all steps up to and including the obtaining of blood tests or DNA tests and thereafter a solicitor's report.",
+            additional_params: [],
+          },
+          {
+            code: "FM004",
+            meaning: "CAFCASS report",
+            description: "Limited to all steps up to and including the Children and Family Reporter's Report and thereafter a solicitor's report.",
+            additional_params: [],
+          },
+          {
+            code: "CV079",
+            meaning: "Counsel's Opinion",
+            description: "Limited to obtaining external Counsel's Opinion or the opinion of an external solicitor with higher court advocacy rights on the information already available.",
+            additional_params: [],
+          },
+          {
+            code: "FM019",
+            meaning: "Exchange of Evidence",
+            description: "Limited to all steps up to and including the exchange of evidence (including any welfare officer's/guardian ad litem's report) and directions appointments but not including a final contested hearing and thereafter to a solicitors report (or if so advised a Counsel's opinion) on the issues and prospects of success.",
+            additional_params: [],
+          },
+          {
+            code: "FM059",
+            meaning: "FHH Children",
+            description: "Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement. To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.",
+            additional_params: [],
+          },
+          {
+            code: "CV118",
+            meaning: "Hearing",
+            description: "Limited to all steps up to and including the hearing on [see additional limitation notes]",
+            additional_params: [],
+          },
+          {
+            code: "CV027",
+            meaning: "Hearing/Adjournment",
+            description: "Limited to all steps (including any adjournment thereof) up to and including the hearing on",
+            additional_params: [],
+          },
+          {
+            code: "CV117",
+            meaning: "Interim order inc. return date",
+            description: "Limited to all steps necessary to apply for an interim order; where application is made without notice to include representation on the return date.",
+            additional_params: [],
+          },
+          {
+            code: "FM015",
+            meaning: "Section 37 Report",
+            description: "Limited to a section 37 report only.",
+            additional_params: [],
+          },
+        ],
+      },
+    }
+  end
+end

--- a/spec/validators/json_validator_spec.rb
+++ b/spec/validators/json_validator_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "JsonValidator" do
+  let(:payload) do
+    {
+      proceeding_type_ccms_code:,
+      delegated_functions_used:,
+      client_involvement_type:,
+      level_of_service_code:,
+    }.to_json
+  end
+
+  let(:proceeding_type_ccms_code) { "SE014" }
+  let(:delegated_functions_used) { false }
+  let(:client_involvement_type) { "W" }
+  let(:level_of_service_code) { 3 }
+
+  let(:schema_name) { "proceeding_type_scopes" }
+
+  let(:validator) { JsonValidator.new(schema_name, payload) }
+
+  context "when valid payload" do
+    it { expect(validator).to be_valid }
+  end
+
+  context "when proceeding_type_ccms_code is invalid and client_involvement_type is invalid" do
+    let(:proceeding_type_ccms_code) { "XX123" }
+    let(:client_involvement_type) { "X" }
+
+    it { expect(validator).not_to be_valid }
+
+    it "displays errors" do
+      expect(validator.errors)
+        .to include(match(/The property '#\/proceeding_type_ccms_code' value "XX123" did not match one of the following values: .* in schema file/))
+        .and include(match(/The property '#\/client_involvement_type' value "X" did not match one of the following values: .* in schema file/))
+    end
+  end
+
+  context "when not all required elements are present" do
+    let(:payload) do
+      {
+        proceeding_type_ccms_code:,
+        delegated_functions_used:,
+        client_involvement_type:,
+      }.to_json
+    end
+
+    it { expect(validator).not_to be_valid }
+
+    it "has the expected errors" do
+      expect(validator.errors)
+        .to match([/The property '#\/' did not contain a required property of 'level_of_service_code' in schema file/])
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -219,6 +219,110 @@ paths:
               - delegated_functions_used
               - client_involvement_type
               - service_level
+  "/proceeding_type_scopes":
+    post:
+      summary: Return details of level_of_service and scope_limitations for specified
+        proceeding_type_ccms_code, delegated_functions_used, client_involvement_type
+        and level_of_service_code
+      description: |-
+        POST a JSON payload containing a proceeding_type_ccms_code, boolean whether delegated_functions_used, client_involvement_type and level_of_service_code
+                          to recieve a payload containing the same request params, and level_of_service and associated scope_limitations.
+      tags:
+      - Proceeding type service level
+      parameters: []
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              example:
+                success: true
+                requested_params:
+                  proceeding_type_ccms_code: SE004
+                  delegated_functions_used: false
+                  client_involvement_type: A
+                  level_of_service_code: 1
+                level_of_service:
+                  level: 1
+                  name: Family Help (Higher)
+                  stage: 1
+                  scope_limitations:
+                  - code: FM007
+                    meaning: Blood Tests or DNA Tests
+                    description: Limited to all steps up to and including the obtaining
+                      of blood tests or DNA tests and thereafter a solicitor's report.
+                    additional_params: []
+                  - code: FM004
+                    meaning: CAFCASS report
+                    description: Limited to all steps up to and including the Children
+                      and Family Reporter's Report and thereafter a solicitor's report.
+                    additional_params: []
+                  - code: CV079
+                    meaning: Counsel's Opinion
+                    description: Limited to obtaining external Counsel''s Opinion
+                      or the opinion of an external solicitor with higher court advocacy
+                      rights on the information already available.
+                    additional_params: []
+                  - code: FM019
+                    meaning: Exchange of Evidence
+                    description: Limited to all steps up to and including the exchange
+                      of evidence (including any welfare officer's/guardian ad litem's
+                      report) and directions appointments but not including a final
+                      contested hearing and thereafter to a solicitors report (or
+                      if so advised a Counsel's opinion) on the issues and prospects
+                      of success.
+                    additional_params: []
+                  - code: FM059
+                    meaning: FHH Children
+                    description: Limited to Family Help (Higher) and to all steps
+                      necessary to negotiate and conclude a settlement. To include
+                      the issue of proceedings and representation in those proceedings
+                      save in relation to or at a contested final hearing.
+                    additional_params: []
+                  - code: CV118
+                    meaning: Hearing
+                    description: Limited to all steps up to and including the hearing
+                      on [see additional limitation notes]
+                    additional_params: []
+                  - code: CV027
+                    meaning: Hearing/Adjournment
+                    description: Limited to all steps (including any adjournment thereof)
+                      up to and including the hearing on [date]
+                    additional_params: []
+                  - code: CV117
+                    meaning: Interim order inc. return date
+                    description: Limited to all steps necessary to apply for an interim
+                      order; where application is made without notice to include representation
+                      on the return date.
+                    additional_params: []
+                  - code: FM015
+                    meaning: Section 37 Report
+                    description: Limited to a section 37 report only.
+                    additional_params: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                proceeding_type_ccms_code:
+                  type: string
+                  description: A code uniquely identifying the proceeding_type
+                delegated_functions_used:
+                  type: boolean
+                  description: A boolean indicating whether delegated functions were
+                    used
+                client_involvement_type:
+                  type: string
+                  description: A code uniquely identifying the client_involvement_type
+                level_of_service_code:
+                  type: integer
+                  description: A code uniquely identifying the service_level
+              required:
+              - proceeding_type_ccms_code
+              - delegated_functions_used
+              - client_involvement_type
+              - service_level
   "/proceeding_types/all":
     get:
       summary: Get summary of all proceeding types
@@ -234,18 +338,21 @@ paths:
           content:
             application/json:
               example:
-              - ccms_code: DA006
-                meaning: Extend, variation or discharge - Part IV
-                description: to be represented on an application to extend, vary or
-                  discharge an order under Part IV Family Law Act 1996
+              - ccms_code: DA001
+                meaning: Inherent jurisdiction high court injunction
+                description: to be represented on an application for an injunction,
+                  order or declaration under the inherent jurisdiction of the court.
                 full_s8_only: false
                 ccms_category_law: Family
                 ccms_matter_code: MINJN
                 ccms_matter: Domestic abuse
-              - ccms_code: DA007
-                meaning: Forced marriage protection order
-                description: to be represented on an application for a forced marriage
-                  protection order
+              - ccms_code: DA002
+                meaning: Variation or discharge under section 5 protection from harassment
+                  act 1997
+                description: to be represented on an application to vary or discharge
+                  an order under section 5 Protection from Harassment Act 1997 where
+                  the parties are associated persons (as defined by Part IV Family
+                  Law Act 1996).
                 full_s8_only: false
                 ccms_category_law: Family
                 ccms_matter_code: MINJN
@@ -254,14 +361,6 @@ paths:
                 meaning: Harassment - injunction
                 description: to be represented in an action for an injunction under
                   section 3 Protection from Harassment Act 1997.
-                full_s8_only: false
-                ccms_category_law: Family
-                ccms_matter_code: MINJN
-                ccms_matter: Domestic abuse
-              - ccms_code: DA001
-                meaning: Inherent jurisdiction high court injunction
-                description: to be represented on an application for an injunction,
-                  order or declaration under the inherent jurisdiction of the court.
                 full_s8_only: false
                 ccms_category_law: Family
                 ccms_matter_code: MINJN
@@ -282,13 +381,18 @@ paths:
                 ccms_category_law: Family
                 ccms_matter_code: MINJN
                 ccms_matter: Domestic abuse
-              - ccms_code: DA002
-                meaning: Variation or discharge under section 5 protection from harassment
-                  act 1997
-                description: to be represented on an application to vary or discharge
-                  an order under section 5 Protection from Harassment Act 1997 where
-                  the parties are associated persons (as defined by Part IV Family
-                  Law Act 1996).
+              - ccms_code: DA006
+                meaning: Extend, variation or discharge - Part IV
+                description: to be represented on an application to extend, vary or
+                  discharge an order under Part IV Family Law Act 1996
+                full_s8_only: false
+                ccms_category_law: Family
+                ccms_matter_code: MINJN
+                ccms_matter: Domestic abuse
+              - ccms_code: DA007
+                meaning: Forced marriage protection order
+                description: to be represented on an application for a forced marriage
+                  protection order
                 full_s8_only: false
                 ccms_category_law: Family
                 ccms_matter_code: MINJN
@@ -310,11 +414,91 @@ paths:
                 ccms_category_law: Family
                 ccms_matter_code: KSEC8
                 ccms_matter: Children - section 8
+              - ccms_code: SE003A
+                meaning: Prohibited Steps Order-Appeal-S8
+                description: to be represented on an application for a prohibited
+                  steps order.  Appeals only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE003E
+                meaning: Prohibited Steps Order-Enforcement-S8
+                description: to be represented on an application for a prohibited
+                  steps order.  Enforcement only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
               - ccms_code: SE004
                 meaning: Specific Issue Order
                 description: to be represented on an application for a specific issue
                   order.
                 full_s8_only: false
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE004A
+                meaning: Specific Issue Order-Appeal-S8
+                description: to be represented on an application for a specific issue
+                  order.  Appeals only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE004E
+                meaning: Specific Issue Order-Enforcement-S8
+                description: to be represented on an application for a specific issue
+                  order.  Enforcement only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE007
+                meaning: Vary/Discharge Prohib Steps Order-S8
+                description: to be represented on an application to vary or discharge
+                  a prohibited steps order.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE007A
+                meaning: Vary/Discharge Prohib Steps Order-Appeal-S8
+                description: to be represented on an application to vary or discharge
+                  a prohibited steps order.  Appeals only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE007E
+                meaning: Vary/Discharge Prohib Steps Order-Enforcement-S8
+                description: to be represented on an application to vary or discharge
+                  a prohibited steps order.  Enforcement only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE008
+                meaning: Vary/Discharge Specific Issues Ord-S8
+                description: to be represented on an application to vary or discharge
+                  a specific issue order.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE008A
+                meaning: Vary/Discharge Specific Issues Ord-Appeal-S8
+                description: to be represented on an application to vary or discharge
+                  a specific issue order.  Appeals only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE008E
+                meaning: Vary/Discharge Specific Issues Ord-Enforcement-S8
+                description: to be represented on an application to vary or discharge
+                  a specific issue order.  Enforcement only.
+                full_s8_only: true
                 ccms_category_law: Family
                 ccms_matter_code: KSEC8
                 ccms_matter: Children - section 8
@@ -326,11 +510,176 @@ paths:
                 ccms_category_law: Family
                 ccms_matter_code: KSEC8
                 ccms_matter: Children - section 8
+              - ccms_code: SE013A
+                meaning: CAO contact-Appeal
+                description: to be represented on an application for a child arrangements
+                  order-who the child(ren) spend time with. Appeals only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE013E
+                meaning: CAO contact-Enforcement
+                description: to be represented on an application for a child arrangements
+                  order-who the child(ren) spend time with. Enforcement only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
               - ccms_code: SE014
                 meaning: Child arrangements order (residence)
                 description: to be represented on an application for a child arrangements
                   order –where the child(ren) will live
                 full_s8_only: false
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE014A
+                meaning: CAO residence-Appeal
+                description: to be represented on an application for a child arrangements
+                  order –where the child(ren) will live. Appeals only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE014E
+                meaning: CAO residence-Enforcement
+                description: to be represented on an application for a child arrangements
+                  order –where the child(ren) will live. Enforcement only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE015
+                meaning: Vary CAO contact
+                description: to be represented on an application to vary/discharge
+                  a child arrangements order-who the child(ren) spend time with.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE015A
+                meaning: Vary CAO contact-Appeal
+                description: to be represented on an application to vary/discharge
+                  a child arrangements order-who the child(ren) spend time with. Appeals
+                  only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE015E
+                meaning: Vary CAO contact-Enforcement
+                description: to be represented on an application to vary/discharge
+                  a child arrangements order-who the child(ren) spend time with. Enforcement
+                  only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE016
+                meaning: Vary CAO residence
+                description: to be represented on an application to vary or discharge
+                  a child arrangements order –where the child(ren) will live.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE016A
+                meaning: Vary CAO residence-Appeal
+                description: to be represented on an application to vary or discharge
+                  a child arrangements order –where the child(ren) will live. Appeals
+                  only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE016E
+                meaning: Vary CAO residence-Enforcement
+                description: to be represented on an application to vary or discharge
+                  a child arrangements order –where the child(ren) will live. Enforcement
+                  only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE095
+                meaning: Enforcement order 11J-S8
+                description: to be represented on an application for an enforcement
+                  order under section 11J Children Act 1989.  Enforcement only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE095A
+                meaning: Enforcement order-Appeal-S8
+                description: to be represented on an application for an enforcement
+                  order under section 11J Children Act 1989.  Appeals only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE096E
+                meaning: Enforcement order+c’tal-S8
+                description: to be represented on an application for committal and
+                  for an enforcement order under section 11J Children Act 1989. Enforcement
+                  only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE097
+                meaning: Revocation enforcement-S8
+                description: to be represented on an application for the revocation
+                  of an enforcement order under section 11J and Schedule A1 Children
+                  Act 1989.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE097A
+                meaning: Revocation enforcement-Appeal-S8
+                description: to be represented on an application for the revocation
+                  of an enforcement order under section 11J and Schedule A1 Children
+                  Act 1989.  Appeals only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE099E
+                meaning: Amd enforcement-breach-S8
+                description: to be represented on an application, following breach,
+                  for an amendment to an enforcement order or for a further enforcement
+                  order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+                  only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE100E
+                meaning: Breach enforcement-S8
+                description: to be represented on an application, following breach,
+                  for an amendment to an enforcement order or for a further enforcement
+                  order under section 11J and Schedule A1 Children Act 1989.  Enforcement
+                  only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE101A
+                meaning: Compensation-Appeal-S8
+                description: to be represented on an application for compensation
+                  for financial loss under section 11O Children Act 1989.  Appeals
+                  only.
+                full_s8_only: true
+                ccms_category_law: Family
+                ccms_matter_code: KSEC8
+                ccms_matter: Children - section 8
+              - ccms_code: SE101E
+                meaning: Compensation-Enforcement-S8
+                description: to be represented on an application for compensation
+                  for financial loss under section 11O Children Act 1989.  Enforcement
+                  only.
+                full_s8_only: true
                 ccms_category_law: Family
                 ccms_matter_code: KSEC8
                 ccms_matter: Children - section 8


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3351)

- implemented a new endpoint /proceeding_type_scopes. This returns level of service, and associated scope_limitations, for a given proceeding_type, client_involvement_type, service_level and delegated_functions_used.
- Implemented json_schema validation for the request payload, similar to that on CFE.

TODO
If we use the json_schema validation we should create a ticket to validate the payload on the /proceeding_type_defaults endpoint (as it is the same as for this endpoint)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
