### PR TITLE
AP-3407 Output Additonal Params with scope details

### DIFF
--- a/app/models/scope_user_input.rb
+++ b/app/models/scope_user_input.rb
@@ -1,3 +1,11 @@
 class ScopeUserInput < ApplicationRecord
   validates :input_type, inclusion: { in: %w[date text], message: "%{value} is not a valid input_type" }
+
+  def as_json
+    {
+      name: input_name,
+      type: input_type,
+      mandatory:,
+    }
+  end
 end


### PR DESCRIPTION
## Output Additonal Params with scope details

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3407)

There are two new endpoints in LFA which output details of scope limitations.  These have been implemented with additional params being an empty array in all cases, pending the creation and seeding of the user_inputs table and the join table to scope_limitations

This PR now outputs details of user_inputs for each scope limitation


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
