### PR TITLE
AP-3407A  Alter proceeding_type_defaults to not take service level as param

### DIFF
--- a/app/models/scope_limitation.rb
+++ b/app/models/scope_limitation.rb
@@ -20,4 +20,13 @@ class ScopeLimitation < ApplicationRecord
 
     find_by!(code: sl_code)
   end
+
+  def as_json
+    {
+      code:,
+      meaning:,
+      description:,
+      additional_params: user_inputs.map(&:as_json),
+    }
+  end
 end

--- a/app/models/scope_user_input.rb
+++ b/app/models/scope_user_input.rb
@@ -1,3 +1,11 @@
 class ScopeUserInput < ApplicationRecord
   validates :input_type, inclusion: { in: %w[date text], message: "%{value} is not a valid input_type" }
+
+  def as_json
+    {
+      name: input_name,
+      type: input_type,
+      mandatory:,
+    }
+  end
 end

--- a/app/models/service_level.rb
+++ b/app/models/service_level.rb
@@ -1,4 +1,12 @@
 class ServiceLevel < ApplicationRecord
   has_many :proceeding_type_service_levels, dependent: :destroy
   has_many :proceeding_types, through: :proceeding_type_service_levels
+
+  def as_json
+    {
+      level:,
+      name:,
+      stage:,
+    }
+  end
 end

--- a/app/services/eligible_scopes_service.rb
+++ b/app/services/eligible_scopes_service.rb
@@ -21,12 +21,20 @@ class EligibleScopesService
     new(proceeding_type, client_involvement_type, service_level, df_used).default_scope
   end
 
+  def self.default_service_level(proceeding_type)
+    new(proceeding_type, nil, nil, nil).default_service_level
+  end
+
   def eligible_scopes
     innermost_config[:scopes]
   end
 
   def default_scope
     innermost_config[:defaults][cit_key]
+  end
+
+  def default_service_level
+    scheme_config[:default_service_level]
   end
 
 private

--- a/app/services/proceeding_type_defaults_service.rb
+++ b/app/services/proceeding_type_defaults_service.rb
@@ -13,7 +13,6 @@ class ProceedingTypeDefaultsService
       @response = create_skeleton_response
       add_default_service_level_to_response
       add_default_scope_to_response
-      add_additional_params_to_response
     else
       @response = error_response
       @errors.concat(json_validator.errors)
@@ -37,17 +36,12 @@ private
 
   def add_default_service_level_to_response
     dsl = ServiceLevel.includes(:proceeding_types, :proceeding_type_service_levels).find_by!(proceeding_types: { ccms_code: proceeding_type_ccms_code }, proceeding_type_service_levels: { proceeding_default: true })
-    @response[:default_level_of_service] = { level: dsl.level, name: dsl.name, stage: dsl.stage }
+    @response[:default_level_of_service] = dsl.as_json
   end
 
   def add_default_scope_to_response
     ds = ScopeLimitation.default_for(proceeding_type_ccms_code, client_involvement_type, level_of_service_code, delegated_functions_used)
-    @response[:default_scope] = { code: ds.code, description: ds.description, meaning: ds.meaning }
-  end
-
-  def add_additional_params_to_response
-    # TODO: populate additional params once scopes that require it populated
-    @response[:additional_params] = []
+    @response[:default_scope] = ds.as_json
   end
 
   def proceeding_type_ccms_code

--- a/app/services/proceeding_type_scopes_service.rb
+++ b/app/services/proceeding_type_scopes_service.rb
@@ -39,12 +39,8 @@ private
   end
 
   def scope_limitations
-    scope_limitations = []
     scopes = ScopeLimitation.eligible_for(proceeding_type_ccms_code, client_involvement_type, level_of_service_code, delegated_functions_used).order(:meaning)
-    scopes.each do |scope|
-      scope_limitations << { code: scope.code, meaning: scope.meaning, description: scope.description, additional_params: [] }
-    end
-    scope_limitations
+    scopes.map(&:as_json)
   end
 
   def proceeding_type_ccms_code

--- a/config/eligible_scopes.yml
+++ b/config/eligible_scopes.yml
@@ -46,8 +46,7 @@
 # schemes
 :schemes:
   :domestic_abuse:
-    :service_levels:
-      - 3
+    :default_service_level: 3
     :service_level_3:
       :substantive:
         :scopes:
@@ -73,6 +72,7 @@
           :cit_a: CV117
           :non_cit_a: CV118
   :section_8_base:
+    :default_service_level: 1
     :service_level_1:
       :substantive:
         :scopes:
@@ -127,6 +127,7 @@
           :cit_a: CV117
           :non_cit_a: CV118
   :section_8_appeals:
+    :default_service_level: 3
     :service_level_3:
       :substantive:
         :scopes:
@@ -201,6 +202,7 @@
           :cit_a: CV118
           :non_cit_a: CV118
   :section_8_enforcements:
+    :default_service_level: 3
     :service_level_3:
       :substantive:
         :scopes:

--- a/public/schemas/proceeding_type_defaults.json.erb
+++ b/public/schemas/proceeding_type_defaults.json.erb
@@ -1,0 +1,22 @@
+{
+  "id": "file://#{@schema_dir}/proceeding_type_defaults.json",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Legal Framework Api proceeding_type_defaults schema",
+  "type": "object",
+  "required": [
+    "proceeding_type_ccms_code",
+    "delegated_functions_used",
+    "client_involvement_type"
+  ],
+  "properties": {
+    "proceeding_type_ccms_code": {
+      "enum": <%= ProceedingType.pluck(:ccms_code).as_json %>
+    },
+    "delegated_functions_used": {
+      "type": "boolean"
+    },
+    "client_involvement_type": {
+      "enum": <%= ClientInvolvementType.pluck(:ccms_code).as_json %>
+    }
+  }
+}

--- a/spec/requests/proceeding_type_defaults_controller_spec.rb
+++ b/spec/requests/proceeding_type_defaults_controller_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "ProceedingTypeDefaultsController", type: :request do
         proceeding_type_ccms_code: "SE013",
         delegated_functions_used: false,
         client_involvement_type: "A",
-        level_of_service_code: 1,
       }
     end
 
@@ -33,7 +32,6 @@ RSpec.describe "ProceedingTypeDefaultsController", type: :request do
           proceeding_type_ccms_code: "XX123",
           delegated_functions_used: false,
           client_involvement_type: "A",
-          level_of_service_code: 1,
         }
       end
 
@@ -56,7 +54,6 @@ RSpec.describe "ProceedingTypeDefaultsController", type: :request do
           proceeding_type_ccms_code: "SE013",
           delegated_functions_used: false,
           client_involvement_type: "A",
-          level_of_service_code: 1,
         },
         default_level_of_service: {
           level: 1,

--- a/spec/requests/proceeding_type_defaults_controller_spec.rb
+++ b/spec/requests/proceeding_type_defaults_controller_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe "ProceedingTypeDefaultsController", type: :request do
           code: "FM059",
           meaning: "FHH Children",
           description: "Limited to Family Help (Higher) and to all steps necessary to negotiate and conclude a settlement. To include the issue of proceedings and representation in those proceedings save in relation to or at a contested final hearing.",
+          additional_params: [],
         },
-        additional_params: [],
       }.as_json
     end
   end

--- a/spec/requests/proceeding_type_scopes_controller_spec.rb
+++ b/spec/requests/proceeding_type_scopes_controller_spec.rb
@@ -79,7 +79,13 @@ RSpec.describe "ProceedingTypeScopesController", type: :request do
               code: "CV079",
               meaning: "Counsel's Opinion",
               description: "Limited to obtaining external Counsel's Opinion or the opinion of an external solicitor with higher court advocacy rights on the information already available.",
-              additional_params: [],
+              additional_params: [
+                {
+                  name: "hearing_date",
+                  type: "date",
+                  mandatory: true,
+                },
+              ],
             },
             {
               code: "FM019",
@@ -97,13 +103,25 @@ RSpec.describe "ProceedingTypeScopesController", type: :request do
               code: "CV118",
               meaning: "Hearing",
               description: "Limited to all steps up to and including the hearing on [see additional limitation notes]",
-              additional_params: [],
+              additional_params: [
+                {
+                  name: "hearing_date",
+                  type: "date",
+                  mandatory: true,
+                },
+              ],
             },
             {
               code: "CV027",
               meaning: "Hearing/Adjournment",
               description: "Limited to all steps (including any adjournment thereof) up to and including the hearing on",
-              additional_params: [],
+              additional_params: [
+                {
+                  name: "hearing_date",
+                  type: "date",
+                  mandatory: true,
+                },
+              ],
             },
             {
               code: "CV117",

--- a/spec/requests/swagger_docs/proceeding_type_defaults_spec.rb
+++ b/spec/requests/swagger_docs/proceeding_type_defaults_spec.rb
@@ -2,9 +2,9 @@ require "swagger_helper"
 
 RSpec.describe "proceeding_type_defaults", type: :request, swagger: true do
   path "/proceeding_type_defaults" do
-    post("Return details of defaults for specified proceeding_type_ccms_code, delegated_functions_used, client_involvement_type") do
+    post("Return details of default scope and level of service for specified proceeding_type_ccms_code, delegated_functions_used, client_involvement_type") do
       description "POST a JSON payload containing a proceeding_type_ccms_code, boolean whether delegated_functions_used and client_involvement_type
-                  to recieve a payload containing the same request params, and the default scope and default level_of_service."
+                  to recieve a payload containing the same request params, and the default scope and level_of_service."
 
       proceeding_type_ccms_code = "SE004"
       delegated_functions_used = false

--- a/spec/requests/swagger_docs/proceeding_type_defaults_spec.rb
+++ b/spec/requests/swagger_docs/proceeding_type_defaults_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "proceeding_type_defaults", type: :request, swagger: true do
                     required: %w[proceeding_type_ccms_code delegated_functions_used client_involvement_type],
                   }
         response(200, "success") do
-          response = ProceedingTypeDefaultsService.call(proceeding_type_defaults_params: { proceeding_type_ccms_code:, delegated_functions_used:, client_involvement_type:}.to_json)
+          response = ProceedingTypeDefaultsService.call(proceeding_type_defaults_params: { proceeding_type_ccms_code:, delegated_functions_used:, client_involvement_type: }.to_json)
 
           examples "application/json" => response
           run_test!

--- a/spec/requests/swagger_docs/proceeding_type_defaults_spec.rb
+++ b/spec/requests/swagger_docs/proceeding_type_defaults_spec.rb
@@ -2,14 +2,13 @@ require "swagger_helper"
 
 RSpec.describe "proceeding_type_defaults", type: :request, swagger: true do
   path "/proceeding_type_defaults" do
-    post("Return details of defaults for specified proceeding_type_ccms_code, delegated_functions_used, client_involvement_type and level_of_service_code") do
-      description "POST a JSON payload containing a proceeding_type_ccms_code, boolean whether delegated_functions_used, client_involvement_type and level_of_service_code
+    post("Return details of defaults for specified proceeding_type_ccms_code, delegated_functions_used, client_involvement_type") do
+      description "POST a JSON payload containing a proceeding_type_ccms_code, boolean whether delegated_functions_used and client_involvement_type
                   to recieve a payload containing the same request params, and the default scope and default level_of_service."
 
       proceeding_type_ccms_code = "SE004"
       delegated_functions_used = false
       client_involvement_type = "A"
-      level_of_service_code = 1
 
       tags "Proceeding types defaults"
       response(200, "successful") do
@@ -26,13 +25,11 @@ RSpec.describe "proceeding_type_defaults", type: :request, swagger: true do
                                                   description: "A boolean indicating whether delegated functions were used" },
                       client_involvement_type: { type: :string,
                                                  description: "A code uniquely identifying the client_involvement_type" },
-                      level_of_service_code: { type: :integer,
-                                               description: "A code uniquely identifying the service_level" },
                     },
-                    required: %w[proceeding_type_ccms_code delegated_functions_used client_involvement_type service_level],
+                    required: %w[proceeding_type_ccms_code delegated_functions_used client_involvement_type],
                   }
         response(200, "success") do
-          response = ProceedingTypeDefaultsService.call(proceeding_type_defaults_params: { proceeding_type_ccms_code:, delegated_functions_used:, client_involvement_type:, level_of_service_code: }.to_json)
+          response = ProceedingTypeDefaultsService.call(proceeding_type_defaults_params: { proceeding_type_ccms_code:, delegated_functions_used:, client_involvement_type:}.to_json)
 
           examples "application/json" => response
           run_test!

--- a/spec/services/eligible_scopes_service_spec.rb
+++ b/spec/services/eligible_scopes_service_spec.rb
@@ -1,185 +1,191 @@
 require "rails_helper"
 
 RSpec.describe EligibleScopesService do
-  describe "section 8 base" do
-    let(:pt_ccms_code) { %w[SE003 SE004 SE007 SE008 SE013 SE014 SE015 SE016 SE095 SE097].sample }
-    let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
-    let(:client_involvement_type_not_a) { %w[D I W Z].sample }
+  let(:s8_base_pt_codes) { %w[SE003 SE004 SE007 SE008 SE013 SE014 SE015 SE016 SE095 SE097] }
+  let(:s8_appeals_pt_codes) { %w[SE003A SE004A SE007A SE008A SE013A SE014A SE015A SE016A SE095A SE097A SE101A] }
+  let(:s8_enforcements_pt_codes) { %w[SE003E SE004E SE007E SE008E SE013E SE014E SE015E SE016E SE096E SE099E SE100E SE101E] }
+  let(:domestic_abuse_pt_codes) { %w[DA001 DA002 DA003 DA004 DA005 DA006 DA007 DA020] }
 
-    context "with service level 1 substantive" do
-      let(:service_level) { 1 }
-      let(:df_used) { false }
-      let(:expected_scopes) { %w[CV027 CV079 CV117 CV118 FM004 FM007 FM015 FM019 FM059] }
+  describe ".default_service_level" do
+    context "with section_8_base" do
+      let(:pt_ccms_code) { %w[SE003 SE004 SE007 SE008 SE013 SE014 SE015 SE016 SE095 SE097].sample }
 
-      it "returns expected eligible scopes" do
-        scopes = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scopes).to match_array(expected_scopes)
-      end
-
-      it "returns the expected default scope" do
-        scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to eq "FM059"
+      it "returns service level 1" do
+        expect(described_class.default_service_level(pt_ccms_code)).to eq 1
       end
     end
 
-    context "with service level 1 delegated functions" do
-      let(:service_level) { 1 }
-      let(:df_used) { true }
-      let(:expected_scopes) { %w[CV027 CV079 CV117 CV118 FM004 FM007 FM015 FM019] }
+    context "with any other scheme" do
+      let(:pt_ccms_code) { (s8_appeals_pt_codes + s8_enforcements_pt_codes + domestic_abuse_pt_codes).sample }
 
-      it "returns the expected scopes" do
-        scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to match_array(expected_scopes)
-      end
-
-      context "with client involvement type A" do
-        let(:client_involvement_type) { "A" }
-
-        it "returns the expected default scope" do
-          scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-          expect(scope).to eq "CV117"
-        end
-      end
-
-      context "with client involvement types not A" do
-        let(:client_involvement_type) { client_involvement_type_not_a }
-
-        it "returns the expected default scope" do
-          scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-          expect(scope).to eq "CV118"
-        end
-      end
-    end
-
-    context "with service level 3 substantive" do
-      let(:service_level) { 3 }
-      let(:df_used) { false }
-      let(:expected_scopes) { %w[CV027 CV117 CV118 FM007 FM019 FM039 FM049] }
-
-      it "returns expected eligible scopes" do
-        scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to match_array(expected_scopes)
-      end
-
-      it "returns the expected default scope" do
-        scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to eq "FM049"
-      end
-    end
-
-    context "with service level 3 delegated functions" do
-      let(:service_level) { 3 }
-      let(:df_used) { true }
-      let(:expected_scopes) { %w[CV027 CV117 CV118 FM007 FM019 FM039 FM049] }
-
-      it "returns the expected scopes" do
-        scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to match_array(expected_scopes)
-      end
-
-      context "with client involvement type A" do
-        let(:client_involvement_type) { "A" }
-
-        it "returns the expected default scope" do
-          scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-          expect(scope).to eq "CV117"
-        end
-      end
-
-      context "with client involvement types not A" do
-        let(:client_involvement_type) { client_involvement_type_not_a }
-
-        it "returns the expected default scope" do
-          scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-          expect(scope).to eq "CV118"
-        end
+      it "returns service level 3" do
+        expect(described_class.default_service_level(pt_ccms_code)).to eq 3
       end
     end
   end
 
-  describe "section 8 appeals" do
-    let(:pt_ccms_code) { %w[SE003A SE004A SE007A SE008A SE013A SE014A SE015A SE016A SE095A SE097A SE101A].sample }
-    let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
-    let(:client_involvement_type_not_a) { %w[D I W Z].sample }
+  describe ".eligible_scopes and .default_scope methods" do
+    describe "section 8 base" do
+      let(:pt_ccms_code) { s8_base_pt_codes.sample }
+      let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
+      let(:client_involvement_type_not_a) { %w[D I W Z].sample }
 
-    context "with service level 3 substantive" do
-      let(:service_level) { 3 }
-      let(:df_used) { false }
-      let(:expected_scopes) { %w[APL07 APL09 APL11 APL13 APL15 APL16 APL18 APL20 APL22 APL27 APL29 APL31 APL48 APL49 APL50 APL51 APL52 APL53 APL54 APL55 APL56 APL57 APL65 APL66 APL67 APL68 APL69 APL70 CV027 CV079 CV118] }
+      context "with service level 1 substantive" do
+        let(:service_level) { 1 }
+        let(:df_used) { false }
+        let(:expected_scopes) { %w[CV027 CV079 CV117 CV118 FM004 FM007 FM015 FM019 FM059] }
 
-      it "returns expected eligible scopes" do
-        scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to match_array(expected_scopes)
-      end
-
-      it "returns the expected default scope" do
-        scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to eq "CV079"
-      end
-    end
-
-    context "with service level 3 delegated functions" do
-      let(:service_level) { 3 }
-      let(:df_used) { true }
-      let(:expected_scopes) { %w[APL07 APL09 APL11 APL13 APL15 APL16 APL18 APL20 APL22 APL27 APL29 APL31 APL48 APL49 APL50 APL51 APL52 APL53 APL54 APL55 APL56 APL57 APL65 APL66 APL67 APL68 APL69 APL70 CV027 CV079 CV118] }
-
-      it "returns the expected scopes" do
-        scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to match_array(expected_scopes)
-      end
-
-      context "with client involvement type A" do
-        let(:client_involvement_type) { "A" }
+        it "returns expected eligible scopes" do
+          scopes = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scopes).to match_array(expected_scopes)
+        end
 
         it "returns the expected default scope" do
           scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-          expect(scope).to eq "CV118"
+          expect(scope).to eq "FM059"
         end
       end
 
-      context "with client involvement types not A" do
-        let(:client_involvement_type) { client_involvement_type_not_a }
+      context "with service level 1 delegated functions" do
+        let(:service_level) { 1 }
+        let(:df_used) { true }
+        let(:expected_scopes) { %w[CV027 CV079 CV117 CV118 FM004 FM007 FM015 FM019] }
+
+        it "returns the expected scopes" do
+          scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "CV117"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "CV118"
+          end
+        end
+      end
+
+      context "with service level 3 substantive" do
+        let(:service_level) { 3 }
+        let(:df_used) { false }
+        let(:expected_scopes) { %w[CV027 CV117 CV118 FM007 FM019 FM039 FM049] }
+
+        it "returns expected eligible scopes" do
+          scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to match_array(expected_scopes)
+        end
 
         it "returns the expected default scope" do
           scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-          expect(scope).to eq "CV118"
+          expect(scope).to eq "FM049"
+        end
+      end
+
+      context "with service level 3 delegated functions" do
+        let(:service_level) { 3 }
+        let(:df_used) { true }
+        let(:expected_scopes) { %w[CV027 CV117 CV118 FM007 FM019 FM039 FM049] }
+
+        it "returns the expected scopes" do
+          scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "CV117"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "CV118"
+          end
         end
       end
     end
-  end
 
-  describe "section 8 enforcements" do
-    let(:pt_ccms_code) { %w[SE003E SE004E SE007E SE008E SE013E SE014E SE015E SE016E SE096E SE099E SE100E SE101E].sample }
-    let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
-    let(:client_involvement_type_not_a) { %w[D I W Z].sample }
-    let(:expected_scopes) { %w[CV027 CV118 EF012 EF022 EF025 EF026 EF027 FM019 FM049 MC029] }
+    describe "section 8 appeals" do
+      let(:pt_ccms_code) { s8_appeals_pt_codes.sample }
+      let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
+      let(:client_involvement_type_not_a) { %w[D I W Z].sample }
 
-    context "with service level 3 substantive" do
-      let(:service_level) { 3 }
-      let(:df_used) { false }
+      context "with service level 3 substantive" do
+        let(:service_level) { 3 }
+        let(:df_used) { false }
+        let(:expected_scopes) { %w[APL07 APL09 APL11 APL13 APL15 APL16 APL18 APL20 APL22 APL27 APL29 APL31 APL48 APL49 APL50 APL51 APL52 APL53 APL54 APL55 APL56 APL57 APL65 APL66 APL67 APL68 APL69 APL70 CV027 CV079 CV118] }
 
-      it "returns expected eligible scopes" do
-        scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to match_array(expected_scopes)
+        it "returns expected eligible scopes" do
+          scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to match_array(expected_scopes)
+        end
+
+        it "returns the expected default scope" do
+          scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to eq "CV079"
+        end
       end
 
-      it "returns the expected default scope" do
-        scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to eq "FM019"
+      context "with service level 3 delegated functions" do
+        let(:service_level) { 3 }
+        let(:df_used) { true }
+        let(:expected_scopes) { %w[APL07 APL09 APL11 APL13 APL15 APL16 APL18 APL20 APL22 APL27 APL29 APL31 APL48 APL49 APL50 APL51 APL52 APL53 APL54 APL55 APL56 APL57 APL65 APL66 APL67 APL68 APL69 APL70 CV027 CV079 CV118] }
+
+        it "returns the expected scopes" do
+          scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "CV118"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "CV118"
+          end
+        end
       end
     end
 
-    context "with service level 3 delegated functions" do
-      let(:service_level) { 3 }
-      let(:df_used) { true }
+    describe "section 8 enforcements" do
+      let(:pt_ccms_code) { s8_enforcements_pt_codes.sample }
+      let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
+      let(:client_involvement_type_not_a) { %w[D I W Z].sample }
+      let(:expected_scopes) { %w[CV027 CV118 EF012 EF022 EF025 EF026 EF027 FM019 FM049 MC029] }
 
-      it "returns the expected scopes" do
-        scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to match_array(expected_scopes)
-      end
+      context "with service level 3 substantive" do
+        let(:service_level) { 3 }
+        let(:df_used) { false }
 
-      context "with client involvement type A" do
-        let(:client_involvement_type) { "A" }
+        it "returns expected eligible scopes" do
+          scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to match_array(expected_scopes)
+        end
 
         it "returns the expected default scope" do
           scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
@@ -187,63 +193,82 @@ RSpec.describe EligibleScopesService do
         end
       end
 
-      context "with client involvement types not A" do
-        let(:client_involvement_type) { client_involvement_type_not_a }
+      context "with service level 3 delegated functions" do
+        let(:service_level) { 3 }
+        let(:df_used) { true }
 
-        it "returns the expected default scope" do
-          scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-          expect(scope).to eq "FM019"
+        it "returns the expected scopes" do
+          scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "FM019"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "FM019"
+          end
         end
       end
     end
-  end
 
-  describe "domestic abuse" do
-    let(:pt_ccms_code) { %w[DA001 DA002 DA003 DA004 DA005 DA006 DA007 DA020].sample }
-    let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
-    let(:client_involvement_type_not_a) { %w[D I W Z].sample }
+    describe "domestic abuse" do
+      let(:pt_ccms_code) { domestic_abuse_pt_codes.sample }
+      let(:client_involvement_type) { ClientInvolvementType::VALID_CLIENT_INVOLVEMENT_TYPES.sample }
+      let(:client_involvement_type_not_a) { %w[D I W Z].sample }
 
-    context "with service level 3 substantive" do
-      let(:service_level) { 3 }
-      let(:df_used) { false }
-      let(:expected_scopes) { %w[AA009 AA019 CV027 CV079 CV117 CV118 FM054] }
+      context "with service level 3 substantive" do
+        let(:service_level) { 3 }
+        let(:df_used) { false }
+        let(:expected_scopes) { %w[AA009 AA019 CV027 CV079 CV117 CV118 FM054] }
 
-      it "returns expected eligible scopes" do
-        scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to match_array(expected_scopes)
-      end
-
-      it "returns the expected default scope" do
-        scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to eq "AA019"
-      end
-    end
-
-    context "with service level 3 delegated functions" do
-      let(:service_level) { 3 }
-      let(:df_used) { true }
-      let(:expected_scopes) { %w[AA009 CV027 CV079 CV117 CV118 FM054] }
-
-      it "returns the expected scopes" do
-        scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
-        expect(scope).to match_array(expected_scopes)
-      end
-
-      context "with client involvement type A" do
-        let(:client_involvement_type) { "A" }
+        it "returns expected eligible scopes" do
+          scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to match_array(expected_scopes)
+        end
 
         it "returns the expected default scope" do
           scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-          expect(scope).to eq "CV117"
+          expect(scope).to eq "AA019"
         end
       end
 
-      context "with client involvement types not A" do
-        let(:client_involvement_type) { client_involvement_type_not_a }
+      context "with service level 3 delegated functions" do
+        let(:service_level) { 3 }
+        let(:df_used) { true }
+        let(:expected_scopes) { %w[AA009 CV027 CV079 CV117 CV118 FM054] }
 
-        it "returns the expected default scope" do
-          scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
-          expect(scope).to eq "CV118"
+        it "returns the expected scopes" do
+          scope = described_class.eligible_scopes(pt_ccms_code, client_involvement_type, service_level, df_used)
+          expect(scope).to match_array(expected_scopes)
+        end
+
+        context "with client involvement type A" do
+          let(:client_involvement_type) { "A" }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "CV117"
+          end
+        end
+
+        context "with client involvement types not A" do
+          let(:client_involvement_type) { client_involvement_type_not_a }
+
+          it "returns the expected default scope" do
+            scope = described_class.default_scope(pt_ccms_code, client_involvement_type, service_level, df_used)
+            expect(scope).to eq "CV118"
+          end
         end
       end
     end

--- a/spec/services/proceeding_type_defaults_service_spec.rb
+++ b/spec/services/proceeding_type_defaults_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe ProceedingTypeDefaultsService do
       proceeding_type_ccms_code:,
       delegated_functions_used:,
       client_involvement_type:,
-      level_of_service_code:,
     }.to_json
   end
   let(:proceeding_type_ccms_code) { "SE003" }
@@ -34,6 +33,64 @@ RSpec.describe ProceedingTypeDefaultsService do
     end
   end
 
+  describe "data integrity" do
+    let(:scenarios) do
+      [
+        [:section_8_base, :cit_a, :df_used, 1, "CV117"],
+        [:section_8_base, :cit_a, :substantive, 1, "FM059"],
+        [:section_8_base, :cit_not_a, :df_used, 1, "CV118"],
+        [:section_8_base, :cit_not_a, :substantive, 1, "FM059"],
+
+        [:section_8_appeals, :cit_a, :df_used, 3, "CV118"],
+        [:section_8_appeals, :cit_a, :substantive, 3, "CV079"],
+        [:section_8_appeals, :cit_not_a, :df_used, 3, "CV118"],
+        [:section_8_appeals, :cit_not_a, :substantive, 3, "CV079"],
+
+        [:section_8_enforcements, :cit_a, :df_used, 3, "FM019"],
+        [:section_8_enforcements, :cit_a, :substantive, 3, "FM019"],
+        [:section_8_enforcements, :cit_not_a, :df_used, 3, "FM019"],
+        [:section_8_enforcements, :cit_not_a, :substantive, 3, "FM019"],
+
+        [:domestic_abuse, :cit_a, :df_used, 3, "CV117"],
+        [:domestic_abuse, :cit_a, :substantive, 3, "AA019"],
+        [:domestic_abuse, :cit_not_a, :df_used, 3, "CV118"],
+        [:domestic_abuse, :cit_not_a, :substantive, 3, "AA019"],
+      ]
+    end
+
+    let(:section_8_base) { %w[SE003 SE004 SE007 SE008 SE013 SE014 SE015 SE016 SE095 SE097].sample }
+    let(:section_8_appeals) { %w[SE003A SE004A SE007A SE008A SE013A SE014A SE015A SE016A SE095A SE097A SE101A].sample }
+    let(:section_8_enforcements) { %w[SE003E SE004E SE007E SE008E SE013E SE014E SE015E SE016E SE096E SE099E SE100E SE101E].sample }
+    let(:domestic_abuse) { %w[DA001 DA002 DA003 DA004 DA005 DA006 DA007 DA020].sample  }
+    let(:cit_a) { "A" }
+    let(:cit_not_a) { %w[D I W Z].sample }
+    let(:df_used) { true }
+    let(:substantive) { false }
+
+    it "generates the expected default service level and scope" do
+      scenarios.each do |scenario|
+        proceeding_type_code, client_involvement_type, df_used, expected_level, expected_scope = scenario
+        payload = generate_payload(proceeding_type_code, client_involvement_type, df_used)
+        response = described_class.call(proceeding_type_defaults_params: payload.to_json)
+        expect(parse_response(response)).to eq([expected_level, expected_scope])
+      end
+    end
+  end
+
+  def generate_payload(proceeding_type_code, client_involvement_type, df_used)
+    {
+      proceeding_type_ccms_code: __send__(proceeding_type_code),
+      delegated_functions_used: __send__(df_used),
+      client_involvement_type: __send__(client_involvement_type),
+    }
+  end
+
+  def parse_response(response)
+    default_service_level = response[:default_level_of_service][:level]
+    default_scope = response[:default_scope][:code]
+    [default_service_level, default_scope]
+  end
+
   def expected_successful_response
     {
       success: true,
@@ -41,7 +98,6 @@ RSpec.describe ProceedingTypeDefaultsService do
         proceeding_type_ccms_code: "SE003",
         delegated_functions_used: true,
         client_involvement_type: "D",
-        level_of_service_code: 1,
       },
       default_level_of_service: {
         level: 1,

--- a/spec/services/proceeding_type_defaults_service_spec.rb
+++ b/spec/services/proceeding_type_defaults_service_spec.rb
@@ -52,8 +52,14 @@ RSpec.describe ProceedingTypeDefaultsService do
         code: "CV118",
         meaning: "Hearing",
         description: "Limited to all steps up to and including the hearing on [see additional limitation notes]",
+        additional_params: [
+          {
+            name: "hearing_date",
+            type: "date",
+            mandatory: true,
+          },
+        ],
       },
-      additional_params: [],
     }
   end
 end

--- a/spec/services/proceeding_type_scopes_service_spec.rb
+++ b/spec/services/proceeding_type_scopes_service_spec.rb
@@ -64,7 +64,13 @@ RSpec.describe ProceedingTypeScopesService do
             code: "CV079",
             meaning: "Counsel's Opinion",
             description: "Limited to obtaining external Counsel's Opinion or the opinion of an external solicitor with higher court advocacy rights on the information already available.",
-            additional_params: [],
+            additional_params: [
+              {
+                name: "hearing_date",
+                type: "date",
+                mandatory: true,
+              },
+            ],
           },
           {
             code: "FM019",
@@ -82,13 +88,25 @@ RSpec.describe ProceedingTypeScopesService do
             code: "CV118",
             meaning: "Hearing",
             description: "Limited to all steps up to and including the hearing on [see additional limitation notes]",
-            additional_params: [],
+            additional_params: [
+              {
+                name: "hearing_date",
+                type: "date",
+                mandatory: true,
+              },
+            ],
           },
           {
             code: "CV027",
             meaning: "Hearing/Adjournment",
             description: "Limited to all steps (including any adjournment thereof) up to and including the hearing on",
-            additional_params: [],
+            additional_params: [
+              {
+                name: "hearing_date",
+                type: "date",
+                mandatory: true,
+              },
+            ],
           },
           {
             code: "CV117",

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -164,9 +164,9 @@ paths:
   "/proceeding_type_defaults":
     post:
       summary: Return details of defaults for specified proceeding_type_ccms_code,
-        delegated_functions_used, client_involvement_type and level_of_service_code
+        delegated_functions_used, client_involvement_type
       description: |-
-        POST a JSON payload containing a proceeding_type_ccms_code, boolean whether delegated_functions_used, client_involvement_type and level_of_service_code
+        POST a JSON payload containing a proceeding_type_ccms_code, boolean whether delegated_functions_used and client_involvement_type
                           to recieve a payload containing the same request params, and the default scope and default level_of_service.
       tags:
       - Proceeding types defaults
@@ -182,7 +182,6 @@ paths:
                   proceeding_type_ccms_code: SE004
                   delegated_functions_used: false
                   client_involvement_type: A
-                  level_of_service_code: 1
                 default_level_of_service:
                   level: 1
                   name: Family Help (Higher)
@@ -211,14 +210,10 @@ paths:
                 client_involvement_type:
                   type: string
                   description: A code uniquely identifying the client_involvement_type
-                level_of_service_code:
-                  type: integer
-                  description: A code uniquely identifying the service_level
               required:
               - proceeding_type_ccms_code
               - delegated_functions_used
               - client_involvement_type
-              - service_level
   "/proceeding_type_scopes":
     post:
       summary: Return details of level_of_service and scope_limitations for specified

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -189,12 +189,12 @@ paths:
                   stage: 1
                 default_scope:
                   code: FM059
+                  meaning: FHH Children
                   description: Limited to Family Help (Higher) and to all steps necessary
                     to negotiate and conclude a settlement. To include the issue of
                     proceedings and representation in those proceedings save in relation
                     to or at a contested final hearing.
-                  meaning: FHH Children
-                additional_params: []
+                  additional_params: []
       requestBody:
         content:
           application/json:
@@ -259,10 +259,13 @@ paths:
                     additional_params: []
                   - code: CV079
                     meaning: Counsel's Opinion
-                    description: Limited to obtaining external Counsel''s Opinion
-                      or the opinion of an external solicitor with higher court advocacy
+                    description: Limited to obtaining external Counsel's Opinion or
+                      the opinion of an external solicitor with higher court advocacy
                       rights on the information already available.
-                    additional_params: []
+                    additional_params:
+                    - name: hearing_date
+                      type: date
+                      mandatory: true
                   - code: FM019
                     meaning: Exchange of Evidence
                     description: Limited to all steps up to and including the exchange
@@ -283,12 +286,18 @@ paths:
                     meaning: Hearing
                     description: Limited to all steps up to and including the hearing
                       on [see additional limitation notes]
-                    additional_params: []
+                    additional_params:
+                    - name: hearing_date
+                      type: date
+                      mandatory: true
                   - code: CV027
                     meaning: Hearing/Adjournment
                     description: Limited to all steps (including any adjournment thereof)
-                      up to and including the hearing on [date]
-                    additional_params: []
+                      up to and including the hearing on
+                    additional_params:
+                    - name: hearing_date
+                      type: date
+                      mandatory: true
                   - code: CV117
                     meaning: Interim order inc. return date
                     description: Limited to all steps necessary to apply for an interim
@@ -792,81 +801,81 @@ paths:
                 error_class: ActiveRecord::RecordNotFound
                 message: 'No such proceeding type: ''XX999'''
                 backtrace:
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activerecord-7.0.3.1/lib/active_record/relation/finder_methods.rb:378:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activerecord-7.0.3.1/lib/active_record/relation/finder_methods.rb:378:in
                   `raise_record_not_found_exception!'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activerecord-7.0.3.1/lib/active_record/core.rb:330:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/activerecord-7.0.3.1/lib/active_record/core.rb:330:in
                   `find_by!'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/app/services/proceeding_type_service.rb:85:in
+                - "/Users/stephenrichards/moj/lfa/app/services/proceeding_type_service.rb:85:in
                   `proceeding_type'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/app/services/proceeding_type_service.rb:33:in
+                - "/Users/stephenrichards/moj/lfa/app/services/proceeding_type_service.rb:33:in
                   `add_matter_type_to_response'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/app/services/proceeding_type_service.rb:25:in
+                - "/Users/stephenrichards/moj/lfa/app/services/proceeding_type_service.rb:25:in
                   `populate_response'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/app/services/proceeding_type_service.rb:16:in
+                - "/Users/stephenrichards/moj/lfa/app/services/proceeding_type_service.rb:16:in
                   `call'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/app/services/proceeding_type_service.rb:5:in
+                - "/Users/stephenrichards/moj/lfa/app/services/proceeding_type_service.rb:5:in
                   `call'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/spec/requests/swagger_docs/proceeding_types_spec.rb:23:in
+                - "/Users/stephenrichards/moj/lfa/spec/requests/swagger_docs/proceeding_types_spec.rb:23:in
                   `block (4 levels) in <top (required)>'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
                   `module_exec'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
                   `subclass'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:271:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:271:in
                   `block in define_example_group_method'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rswag-specs-2.5.1/lib/rswag/specs/example_group_helpers.rb:56:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rswag-specs-2.5.1/lib/rswag/specs/example_group_helpers.rb:56:in
                   `response'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/spec/requests/swagger_docs/proceeding_types_spec.rb:22:in
+                - "/Users/stephenrichards/moj/lfa/spec/requests/swagger_docs/proceeding_types_spec.rb:22:in
                   `block (3 levels) in <top (required)>'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
                   `module_exec'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
                   `subclass'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:271:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:271:in
                   `block in define_example_group_method'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rswag-specs-2.5.1/lib/rswag/specs/example_group_helpers.rb:14:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rswag-specs-2.5.1/lib/rswag/specs/example_group_helpers.rb:14:in
                   `block (2 levels) in <module:ExampleGroupHelpers>'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/spec/requests/swagger_docs/proceeding_types_spec.rb:11:in
+                - "/Users/stephenrichards/moj/lfa/spec/requests/swagger_docs/proceeding_types_spec.rb:11:in
                   `block (2 levels) in <top (required)>'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
                   `module_exec'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
                   `subclass'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:271:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:271:in
                   `block in define_example_group_method'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rswag-specs-2.5.1/lib/rswag/specs/example_group_helpers.rb:8:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rswag-specs-2.5.1/lib/rswag/specs/example_group_helpers.rb:8:in
                   `path'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/spec/requests/swagger_docs/proceeding_types_spec.rb:4:in
+                - "/Users/stephenrichards/moj/lfa/spec/requests/swagger_docs/proceeding_types_spec.rb:4:in
                   `block in <top (required)>'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
                   `module_exec'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:398:in
                   `subclass'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:271:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/example_group.rb:271:in
                   `block in define_example_group_method'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/dsl.rb:43:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/dsl.rb:43:in
                   `block in expose_example_group_alias'"
-                - "/Users/katharineahern/workspaces/legal-framework-api/spec/requests/swagger_docs/proceeding_types_spec.rb:3:in
+                - "/Users/stephenrichards/moj/lfa/spec/requests/swagger_docs/proceeding_types_spec.rb:3:in
                   `<top (required)>'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2115:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2115:in
                   `load'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2115:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:2115:in
                   `load_file_handling_errors'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:1615:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:1615:in
                   `block in load_spec_files'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:1613:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:1613:in
                   `each'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:1613:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/configuration.rb:1613:in
                   `load_spec_files'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:102:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:102:in
                   `setup'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:86:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:86:in
                   `run'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:71:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:71:in
                   `run'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:45:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/lib/rspec/core/runner.rb:45:in
                   `invoke'"
-                - "/Users/katharineahern/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/exe/rspec:4:in
+                - "/Users/stephenrichards/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/rspec-core-3.11.0/exe/rspec:4:in
                   `<main>'"
   "/proceeding_types/threshold_waivers":
     post:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -163,11 +163,11 @@ paths:
               - values
   "/proceeding_type_defaults":
     post:
-      summary: Return details of defaults for specified proceeding_type_ccms_code,
-        delegated_functions_used, client_involvement_type
+      summary: Return details of default scope and level of service for specified
+        proceeding_type_ccms_code, delegated_functions_used, client_involvement_type
       description: |-
         POST a JSON payload containing a proceeding_type_ccms_code, boolean whether delegated_functions_used and client_involvement_type
-                          to recieve a payload containing the same request params, and the default scope and default level_of_service.
+                          to recieve a payload containing the same request params, and the default scope and level_of_service.
       tags:
       - Proceeding types defaults
       parameters: []


### PR DESCRIPTION
## Alter proceeding_type_defaults to not take service level as param

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3407)

This is rebased of AP-3407.

The `proceeding_type_defaults` endpoint no longer takes service level as a parameter - it doesn't make sense as it's the default service level and default scope limitation that is returned as a response to this call.

The internal workings of this was also changed to use the `EligibleScopeService` as this uses the yaml config file which is the source of truth for full section 8, unlike the old join table which only has data relating to the section 8 proceedings that we already handle.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
