### PR TITLE
Fix/json schema proceeding array validation

### DIFF
--- a/app/services/questions_service.rb
+++ b/app/services/questions_service.rb
@@ -1,6 +1,4 @@
 class QuestionsService
-  class InvalidSubmissionError < StandardError; end
-
   def initialize(question_params)
     @question_params = JSON.parse(question_params, symbolize_names: true)
     @request_id =  @question_params[:request_id]
@@ -14,8 +12,6 @@ class QuestionsService
   end
 
   def call
-    raise InvalidSubmissionError, "Must specify at least one proceeding" if @proceedings.empty?
-
     if json_validator.valid?
       @proceedings.each { |proceeding| add_tasks_to_response(proceeding) }
     else

--- a/public/schemas/civil_merits_questions.json.erb
+++ b/public/schemas/civil_merits_questions.json.erb
@@ -14,6 +14,7 @@
     },
     "proceedings": {
       "type": "array",
+      "minItems": 1,
       "items": {
         "type": "object",
         "required": [

--- a/spec/services/questions_service_spec.rb
+++ b/spec/services/questions_service_spec.rb
@@ -84,8 +84,10 @@ RSpec.describe QuestionsService do
     context "when no proceedings data is supplied" do
       let(:proceedings) { [] }
 
-      it "raises an error" do
-        expect { question_service }.to raise_error(QuestionsService::InvalidSubmissionError, "Must specify at least one proceeding")
+      it "returns error" do
+        response = question_service
+        expect(response[:success]).to be false
+        expect(response[:errors]).to match [/The property '#\/proceedings' did not contain a minimum number of items 1 in schema file/]
       end
     end
 


### PR DESCRIPTION
## What

Update CivilMeritsQuestion JsonSchema
Set a MinItems value of 1, this ensures that the validation will raise an error if an empty array is submitted.  This removes the need for separate error handling as we had re-used a method to raise an error when the array was empty

After some research, this is a better way of sticking to a single validation method using the JsonSchema we defined

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
