### PR TITLE
ap-3546: fix for proceeding_type_service failing with new proceeding …

### DIFF
--- a/app/services/proceeding_type_service.rb
+++ b/app/services/proceeding_type_service.rb
@@ -55,6 +55,8 @@ private
   def add_scope_limitations_to_response
     scl = substantive_scope_limitations
     dfcl = delegated_functions_scope_limitations
+    return unless scl && dfcl
+
     @response[:default_scope_limitations] = { substantive: { code: scl.code, meaning: scl.meaning, description: scl.description },
                                               delegated_functions: { code: dfcl.code, meaning: dfcl.meaning, description: dfcl.description } }
   end
@@ -74,11 +76,11 @@ private
   end
 
   def delegated_functions_scope_limitations
-    proceeding_type.proceeding_type_scope_limitations.default_delegated_functions_scope_limitation
+    proceeding_type.proceeding_type_scope_limitations&.default_delegated_functions_scope_limitation
   end
 
   def substantive_scope_limitations
-    proceeding_type.proceeding_type_scope_limitations.default_substantive_scope_limitation
+    proceeding_type.proceeding_type_scope_limitations&.default_substantive_scope_limitation
   end
 
   def proceeding_type

--- a/spec/services/proceeding_type_service_spec.rb
+++ b/spec/services/proceeding_type_service_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe ProceedingTypeService do
         expect(response[:backtrace]).to be_instance_of(Array)
       end
     end
+
+    context "with a valid new s8 proceeding type" do
+      let(:ccms_code) { %w[SE003A] }
+
+      it "returns valid response without scope limitations or service levels" do
+        expect(proceeding_type_service_response).to eq expected_se003a_response
+      end
+    end
   end
 
   def expected_da003_response
@@ -148,6 +156,33 @@ RSpec.describe ProceedingTypeService do
           proceeding_default: false,
         },
       ],
+    }
+  end
+
+  def expected_se003a_response
+    {
+      success: true,
+      ccms_code: "SE003A",
+      meaning: "Prohibited Steps Order-Appeal-S8",
+      ccms_category_law_code: "MAT",
+      ccms_matter_code: "KSEC8",
+      name: "prohibited_steps_order_appeal_s8",
+      description: "to be represented on an application for a prohibited steps order.  Appeals only.",
+      full_s8_only: true,
+      ccms_category_law: "Family",
+      ccms_matter: "Children - section 8",
+      cost_limitations: {
+        substantive: {
+          start_date: "1970-01-01",
+          value: "25000.0",
+        },
+        delegated_functions: {
+          start_date: "2021-09-13",
+          value: "2250.0",
+        },
+      },
+      default_scope_limitations: {},
+      service_levels: [],
     }
   end
 end


### PR DESCRIPTION
…types


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3546)

In apply, selecting one of the new proceeding types was causing a 500 error.

On investigation it was found that this was because the call to the LFA proceeding _types endpoint was failing with a 400 Bad Request. This is because it was attempting to populate scope_limitations in the response, but these have not been seeded for the new proceeding types https://github.com/ministryofjustice/legal-framework-api/blob/main/db/seed_data/proceeding_type_scope_limitations.yml. This resulted in no proceeding_type being returned.

The attempted fix is to return an empty hash for scope_limitations when one of the proceeding type codes is requested (ie when no scope limitations are found). This has been tested locally in apply and I believe it works as long as we do not give any firms the full s8 permissions before enabling the proceeding loop, as the apply code already skips populating scope limitations for calls to this endpoint if the proceeding_loop is enabled https://github.com/ministryofjustice/laa-apply-for-legal-aid/blob/b6788107cc86deab96f5a7483a54768fcdd55266/app/services/legal_framework/add_proceeding_service.rb#L14

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
