### PR TITLE
Add gemlock file to bump rspec-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ DEPENDENCIES
   puma (~> 5.6)
   rack-cors
   rails (~> 7.0.4)
-  rspec-rails (~> 6.0)
+  rspec-rails (~> 6.0, >= 6.0.1)
   rspec_junit_formatter
   rswag-api
   rswag-specs


### PR DESCRIPTION
## What
bump rspec-rails in lock file

[Snyk fix](https://github.com/ministryofjustice/legal-framework-api/pull/764) did not bump the lock file :(
but should have.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
