### PR TITLE
AP-3571: Update section 8 tasks seed

### DIFF
--- a/app/services/questions_service.rb
+++ b/app/services/questions_service.rb
@@ -46,7 +46,7 @@ private
     applicable_tasks = proceeding_type.application_tasks
     applicable_tasks.each do |task|
       display_rules = task.proceeding_type_merits_tasks.find_by(proceeding_type_id: proceeding_type.id).display_rules
-      display_task = display_rules.nil? || send(display_rules)
+      display_task = display_rules.nil? || send(display_rules, proceeding_type)
       @response[:application][:tasks][task.name] = task.dependency_names if display_task
     end
   end
@@ -54,18 +54,29 @@ private
   def add_proceeding_level_tasks_to_response(proceeding_type, ccms_code)
     pt_hash = { ccms_code:, tasks: {} }
     proceeding_type.proceeding_tasks.each do |task|
-      pt_hash[:tasks][task.name] = task.dependency_names
+      display_rules = task.proceeding_type_merits_tasks.find_by(proceeding_type_id: proceeding_type.id).display_rules
+      display_task = display_rules.nil? || send(display_rules, proceeding_type)
+      pt_hash[:tasks][task.name] = task.dependency_names if display_task
     end
     @response[:proceedings] << pt_hash
   end
 
-  def domestic_abuse_with_non_applicant
+  def domestic_abuse_with_non_applicant(_proceeding)
     @proceedings.select { |h| h[:ccms_code].match(/DA\d{3}/) && h[:client_involvement_type] != "A" }.any?
   end
 
-  def always_unless_all_da_and_non_applicant
+  def always_unless_all_da_and_non_applicant(_proceeding)
     matches = @proceedings.select { |h| h[:ccms_code].match(/DA\d{3}/) && h[:client_involvement_type] != "A" }
     return true unless matches.present? && matches.all?
+  end
+
+  def delegated_functions_on_any_proceeding(_proceeding)
+    @proceedings.select { |proceeding| proceeding[:delegated_functions_used].to_s == "true" }.any?
+  end
+
+  def defendant_on_this_proceeding(proceeding)
+    match = @proceedings.find { |e| e[:ccms_code] == proceeding.ccms_code && e[:client_involvement_type] == "D" }
+    match.present?
   end
 
   def error_response

--- a/app/services/questions_service.rb
+++ b/app/services/questions_service.rb
@@ -45,20 +45,21 @@ private
   def add_application_level_tasks_to_response(proceeding_type)
     applicable_tasks = proceeding_type.application_tasks
     applicable_tasks.each do |task|
-      display_rules = task.proceeding_type_merits_tasks.find_by(proceeding_type_id: proceeding_type.id).display_rules
-      display_task = display_rules.nil? || send(display_rules, proceeding_type)
-      @response[:application][:tasks][task.name] = task.dependency_names if display_task
+      @response[:application][:tasks][task.name] = task.dependency_names if display_rules_for(proceeding_type, task)
     end
   end
 
   def add_proceeding_level_tasks_to_response(proceeding_type, ccms_code)
     pt_hash = { ccms_code:, tasks: {} }
     proceeding_type.proceeding_tasks.each do |task|
-      display_rules = task.proceeding_type_merits_tasks.find_by(proceeding_type_id: proceeding_type.id).display_rules
-      display_task = display_rules.nil? || send(display_rules, proceeding_type)
-      pt_hash[:tasks][task.name] = task.dependency_names if display_task
+      pt_hash[:tasks][task.name] = task.dependency_names if display_rules_for(proceeding_type, task)
     end
     @response[:proceedings] << pt_hash
+  end
+
+  def display_rules_for(proceeding_type, task)
+    display_rules = task.proceeding_type_merits_tasks.find_by(proceeding_type_id: proceeding_type.id).display_rules
+    display_rules.nil? || send(display_rules, proceeding_type)
   end
 
   def domestic_abuse_with_non_applicant(_proceeding)

--- a/db/populators/merits_task_populator.rb
+++ b/db/populators/merits_task_populator.rb
@@ -6,12 +6,18 @@ class MeritsTaskPopulator
     statement_of_case
     client_denial_of_allegation
     client_offer_of_undertakings
+    nature_of_urgency
+    why_matter_opposed
   ].freeze
 
   PROCEEDING_TYPE_MERITS_TASKS = %w[
     chances_of_success
     children_proceeding
     attempts_to_settle
+    specific_issue
+    prohibited_steps
+    opponents_application
+    reason_for_new_application
   ].freeze
 
   def self.call

--- a/db/seed_data/proceeding_type_merits_task.yml
+++ b/db/seed_data/proceeding_type_merits_task.yml
@@ -11,6 +11,10 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
+  - delegated_functions_on_any_proceeding:
+    - nature_of_urgency
+  - defendant_on_this_proceeding:
+    - opponents_application
 - ccms_code: "DA002"
   questions:
   - always_unless_all_da_and_non_applicant:
@@ -21,6 +25,10 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "DA003"
   questions:
   - always_unless_all_da_and_non_applicant:
@@ -31,6 +39,10 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "DA004"
   questions:
   - always_unless_all_da_and_non_applicant:
@@ -41,6 +53,10 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "DA005"
   questions:
   - always_unless_all_da_and_non_applicant:
@@ -51,6 +67,10 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "DA006"
   questions:
   - always_unless_all_da_and_non_applicant:
@@ -61,6 +81,10 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "DA007"
   questions:
   - always_unless_all_da_and_non_applicant:
@@ -71,6 +95,10 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "DA020"
   questions:
   - always_unless_all_da_and_non_applicant:
@@ -81,6 +109,10 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "SE003"
   questions:
   - latest_incident_details
@@ -90,6 +122,12 @@
   - children_application
   - children_proceeding
   - attempts_to_settle
+  - prohibited_steps
+  - why_matter_opposed
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "SE004"
   questions:
   - latest_incident_details
@@ -99,6 +137,26 @@
   - children_application
   - children_proceeding
   - attempts_to_settle
+  - specific_issue
+  - why_matter_opposed
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
+- ccms_code: "SE007"
+  questions:
+  - latest_incident_details
+  - opponent_details
+  - statement_of_case
+  - chances_of_success
+  - children_application
+  - children_proceeding
+  - attempts_to_settle
+  - reason_for_new_application
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "SE013"
   questions:
   - latest_incident_details
@@ -108,6 +166,11 @@
   - children_application
   - children_proceeding
   - attempts_to_settle
+  - why_matter_opposed
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application
 - ccms_code: "SE014"
   questions:
   - latest_incident_details
@@ -117,3 +180,8 @@
   - children_application
   - children_proceeding
   - attempts_to_settle
+  - why_matter_opposed
+  - delegated_functions_on_any_proceeding:
+      - nature_of_urgency
+  - defendant_on_this_proceeding:
+      - opponents_application

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -44,21 +44,21 @@ RSpec.describe ProceedingType do
       it "returns ordered list of all merits tasks" do
         rec = described_class.find_by(ccms_code: "DA003")
         tasks = rec.merits_tasks.pluck(:name)
-        expect(tasks).to eq %w[latest_incident_details opponent_details statement_of_case chances_of_success client_denial_of_allegation client_offer_of_undertakings]
+        expect(tasks).to eq %w[latest_incident_details opponent_details statement_of_case chances_of_success client_denial_of_allegation client_offer_of_undertakings nature_of_urgency opponents_application]
       end
     end
 
     describe "application_tasks" do
       it "returns ordered list of application tasks only" do
         rec = described_class.find_by(ccms_code: "DA003")
-        expect(rec.application_tasks.map(&:name)).to eq %w[latest_incident_details opponent_details statement_of_case client_denial_of_allegation client_offer_of_undertakings]
+        expect(rec.application_tasks.map(&:name)).to eq %w[latest_incident_details opponent_details statement_of_case client_denial_of_allegation client_offer_of_undertakings nature_of_urgency]
       end
     end
 
     describe "proceeding_tasks" do
       it "returns ordered list of proceeding_level tasks only" do
         rec = described_class.find_by(ccms_code: "DA003")
-        expect(rec.proceeding_tasks.map(&:name)).to eq %w[chances_of_success]
+        expect(rec.proceeding_tasks.map(&:name)).to eq %w[chances_of_success opponents_application]
       end
     end
 

--- a/spec/requests/civil_merits_questions_controller_swagger_spec.rb
+++ b/spec/requests/civil_merits_questions_controller_swagger_spec.rb
@@ -64,12 +64,15 @@ RSpec.describe "civil_merits_questions", type: :request do
                   latest_incident_details: [],
                   opponent_details: [],
                   statement_of_case: [],
+                  nature_of_urgency: [],
                 },
               },
               proceedings: [
                 {
                   ccms_code: "DA001",
-                  tasks: { chances_of_success: [] },
+                  tasks: {
+                    chances_of_success: [],
+                  },
                 },
               ],
             }
@@ -103,12 +106,16 @@ RSpec.describe "civil_merits_questions", type: :request do
                   statement_of_case: [],
                   client_denial_of_allegation: [],
                   client_offer_of_undertakings: [],
+                  nature_of_urgency: [],
                 },
               },
               proceedings: [
                 {
                   ccms_code: "DA001",
-                  tasks: { chances_of_success: [] },
+                  tasks: {
+                    chances_of_success: [],
+                    opponents_application: [],
+                  },
                 },
               ],
             }

--- a/spec/requests/merits_tasks_controller_swagger_spec.rb
+++ b/spec/requests/merits_tasks_controller_swagger_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe "merits_tasks", type: :request do
                 "opponent_details" => [],
                 "statement_of_case" => [],
                 "children_application" => [],
+                "why_matter_opposed" => [],
               },
             },
             proceeding_types: [
@@ -61,6 +62,7 @@ RSpec.describe "merits_tasks", type: :request do
                 ccms_code: "DA005",
                 tasks: {
                   "chances_of_success" => [],
+                  "opponents_application" => [],
                 },
               },
               {
@@ -69,6 +71,8 @@ RSpec.describe "merits_tasks", type: :request do
                   "chances_of_success" => [],
                   "children_proceeding" => %w[children_application],
                   "attempts_to_settle" => [],
+                  "specific_issue" => [],
+                  "opponents_application" => [],
                 },
               },
               {
@@ -77,6 +81,7 @@ RSpec.describe "merits_tasks", type: :request do
                   "chances_of_success" => [],
                   "children_proceeding" => %w[children_application],
                   "attempts_to_settle" => [],
+                  "opponents_application" => [],
                 },
               },
             ],

--- a/spec/services/merits_task_service_spec.rb
+++ b/spec/services/merits_task_service_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe MeritsTaskService do
           ccms_code: "DA005",
           tasks: {
             "chances_of_success" => [],
+            "opponents_application" => [],
           },
         },
       ],
@@ -81,6 +82,7 @@ RSpec.describe MeritsTaskService do
           "opponent_details" => [],
           "statement_of_case" => [],
           "children_application" => [],
+          "why_matter_opposed" => [],
         },
       },
       proceeding_types: [
@@ -88,6 +90,7 @@ RSpec.describe MeritsTaskService do
           ccms_code: "DA005",
           tasks: {
             "chances_of_success" => [],
+            "opponents_application" => [],
           },
         },
         {
@@ -96,6 +99,8 @@ RSpec.describe MeritsTaskService do
             "chances_of_success" => [],
             "children_proceeding" => %w[children_application],
             "attempts_to_settle" => [],
+            "opponents_application" => [],
+            "prohibited_steps" => [],
           },
         },
         {
@@ -104,6 +109,7 @@ RSpec.describe MeritsTaskService do
             "chances_of_success" => [],
             "children_proceeding" => %w[children_application],
             "attempts_to_settle" => [],
+            "opponents_application" => [],
           },
         },
       ],

--- a/spec/services/questions_service_spec.rb
+++ b/spec/services/questions_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe QuestionsService do
       end
 
       it "returns valid response without domestic abuse/non applicant questions" do
-        expect(question_service).to eq expected_multiple_no_questions_response
+        expect(question_service).to eq expected_multiple_no_questions_response_with_defendant
       end
     end
 
@@ -111,6 +111,7 @@ RSpec.describe QuestionsService do
           "latest_incident_details" => [],
           "opponent_details" => [],
           "statement_of_case" => [],
+          "nature_of_urgency" => [],
         },
       },
       proceedings: [
@@ -134,6 +135,7 @@ RSpec.describe QuestionsService do
           "statement_of_case" => [],
           "client_denial_of_allegation" => [],
           "client_offer_of_undertakings" => [],
+          "nature_of_urgency" => [],
         },
       },
       proceedings: [
@@ -141,6 +143,7 @@ RSpec.describe QuestionsService do
           ccms_code: "DA005",
           tasks: {
             "chances_of_success" => [],
+            "opponents_application" => [],
           },
         },
       ],
@@ -157,6 +160,8 @@ RSpec.describe QuestionsService do
           "opponent_details" => [],
           "statement_of_case" => [],
           "children_application" => [],
+          "nature_of_urgency" => [],
+          "why_matter_opposed" => [],
         },
       },
       proceedings: [
@@ -172,6 +177,40 @@ RSpec.describe QuestionsService do
             "chances_of_success" => [],
             "children_proceeding" => %w[children_application],
             "attempts_to_settle" => [],
+          },
+        },
+      ],
+    }
+  end
+
+  def expected_multiple_no_questions_response_with_defendant
+    {
+      request_id:,
+      success: true,
+      application: {
+        tasks: {
+          "latest_incident_details" => [],
+          "opponent_details" => [],
+          "statement_of_case" => [],
+          "children_application" => [],
+          "nature_of_urgency" => [],
+          "why_matter_opposed" => [],
+        },
+      },
+      proceedings: [
+        {
+          ccms_code: "DA005",
+          tasks: {
+            "chances_of_success" => [],
+          },
+        },
+        {
+          ccms_code: "SE013",
+          tasks: {
+            "chances_of_success" => [],
+            "children_proceeding" => %w[children_application],
+            "attempts_to_settle" => [],
+            "opponents_application" => [],
           },
         },
       ],

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -27,6 +27,7 @@ paths:
                         latest_incident_details: []
                         opponent_details: []
                         statement_of_case: []
+                        nature_of_urgency: []
                     proceedings:
                     - ccms_code: DA001
                       tasks:
@@ -44,10 +45,12 @@ paths:
                         statement_of_case: []
                         client_denial_of_allegation: []
                         client_offer_of_undertakings: []
+                        nature_of_urgency: []
                     proceedings:
                     - ccms_code: DA001
                       tasks:
                         chances_of_success: []
+                        opponents_application: []
                   summary: Successful request with extra questions
                   description: Request a single proceeding, DA001, triggering additional,
                     domestic abuse, questions
@@ -172,22 +175,27 @@ paths:
                         opponent_details: []
                         statement_of_case: []
                         children_application: []
+                        why_matter_opposed: []
                     proceeding_types:
                     - ccms_code: DA005
                       tasks:
                         chances_of_success: []
+                        opponents_application: []
                     - ccms_code: SE004
                       tasks:
                         chances_of_success: []
                         children_proceeding:
                         - children_application
                         attempts_to_settle: []
+                        specific_issue: []
+                        opponents_application: []
                     - ccms_code: SE013
                       tasks:
                         chances_of_success: []
                         children_proceeding:
                         - children_application
                         attempts_to_settle: []
+                        opponents_application: []
                   summary: Successful request
                   description: A request for three proceedings returns a set of tasks
                     with dependencies


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3571)

Update the proceeding_type_merits_task seed data with the new section 8 questions
Add new display rules into the QuestionService to handle the new changes
Update existing tests to ensure new rules are applied appropriately and are adding new tasks where needed
Update the swagger docs so that examples include the responses

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
