### PR TITLE
Fix: Remove latest_incident from non Domestic Abuse proceedings

### DIFF
--- a/db/seed_data/proceeding_type_merits_task.yml
+++ b/db/seed_data/proceeding_type_merits_task.yml
@@ -115,7 +115,6 @@
       - opponents_application
 - ccms_code: "SE003"
   questions:
-  - latest_incident_details
   - opponent_details
   - statement_of_case
   - chances_of_success
@@ -130,7 +129,6 @@
       - opponents_application
 - ccms_code: "SE004"
   questions:
-  - latest_incident_details
   - opponent_details
   - statement_of_case
   - chances_of_success
@@ -145,7 +143,6 @@
       - opponents_application
 - ccms_code: "SE007"
   questions:
-  - latest_incident_details
   - opponent_details
   - statement_of_case
   - chances_of_success
@@ -173,7 +170,6 @@
       - opponents_application
 - ccms_code: "SE014"
   questions:
-  - latest_incident_details
   - opponent_details
   - statement_of_case
   - chances_of_success


### PR DESCRIPTION
## What

This question has traditionally been displayed on all applications because they all had a DA proceeding where the client was an applicant.

That rule, and limitation, is changing and it is not required _at all_ for non Domestic Abuse proceedings

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
