### PR TITLE
AP-3489 replace reason_for_new_application with vary_order merits_task

### DIFF
--- a/db/populators/merits_task_populator.rb
+++ b/db/populators/merits_task_populator.rb
@@ -19,6 +19,7 @@ class MeritsTaskPopulator
     prohibited_steps
     opponents_application
     reason_for_new_application
+    vary_order
   ].freeze
 
   def self.call

--- a/db/populators/merits_task_populator.rb
+++ b/db/populators/merits_task_populator.rb
@@ -18,7 +18,6 @@ class MeritsTaskPopulator
     specific_issue
     prohibited_steps
     opponents_application
-    reason_for_new_application
     vary_order
   ].freeze
 
@@ -27,6 +26,8 @@ class MeritsTaskPopulator
   end
 
   def call
+    destroy_unseeded_merits_tasks
+
     APPLICATION_MERITS_TASKS.each do |mt|
       populate(mt, ApplicationTask)
     end
@@ -41,5 +42,9 @@ private
   def populate(merits_task, klass)
     record = klass.find_by(name: merits_task) || klass.new
     record.update!(name: merits_task)
+  end
+
+  def destroy_unseeded_merits_tasks
+    MeritsTask.where.not(name: APPLICATION_MERITS_TASKS + PROCEEDING_TYPE_MERITS_TASKS).destroy_all
   end
 end

--- a/db/seed_data/proceeding_type_merits_task.yml
+++ b/db/seed_data/proceeding_type_merits_task.yml
@@ -153,6 +153,7 @@
   - children_proceeding
   - attempts_to_settle
   - reason_for_new_application
+  - vary_order
   - delegated_functions_on_any_proceeding:
       - nature_of_urgency
   - defendant_on_this_proceeding:

--- a/db/seed_data/proceeding_type_merits_task.yml
+++ b/db/seed_data/proceeding_type_merits_task.yml
@@ -152,7 +152,6 @@
   - laspo
   - children_proceeding
   - attempts_to_settle
-  - reason_for_new_application
   - vary_order
   - delegated_functions_on_any_proceeding:
       - nature_of_urgency

--- a/db/seed_data/proceeding_type_merits_task.yml
+++ b/db/seed_data/proceeding_type_merits_task.yml
@@ -22,6 +22,7 @@
   - opponent_details
   - statement_of_case
   - chances_of_success
+  - vary_order
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
@@ -78,6 +79,7 @@
   - opponent_details
   - statement_of_case
   - chances_of_success
+  - vary_order
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings


### PR DESCRIPTION
## What
Replace reasons_for_new_application vary_order merits_task and proceeding_type_merits_task

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3489)

Rename reason_for_new_application --> vary_order
as from discussion between JS and CB it was agreed that
the name of the merits task is more clearly and concisely
covered by vary_order.

This name is to be used by Apply as well for the merits
question logic - see https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/4518





## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
