### PR TITLE
AP-3591: Update display_rule for latest_incident_details question

### DIFF
--- a/app/services/merits_task_service.rb
+++ b/app/services/merits_task_service.rb
@@ -40,7 +40,7 @@ private
   end
 
   def add_application_level_tasks_to_response(proceeding_type)
-    applicable_tasks = proceeding_type.application_tasks.where("display_rules IS NULL OR display_rules = 'always_unless_all_da_and_non_applicant'")
+    applicable_tasks = proceeding_type.application_tasks.where("display_rules IS NULL OR display_rules = 'at_least_one_domestic_abuse_with_applicant'")
     applicable_tasks.each do |task|
       @response[:application][:tasks][task.name] = task.dependency_names
     end

--- a/app/services/questions_service.rb
+++ b/app/services/questions_service.rb
@@ -66,9 +66,8 @@ private
     @proceedings.select { |h| h[:ccms_code].match(/DA\d{3}/) && h[:client_involvement_type] != "A" }.any?
   end
 
-  def always_unless_all_da_and_non_applicant(_proceeding)
-    matches = @proceedings.select { |h| h[:ccms_code].match(/DA\d{3}/) && h[:client_involvement_type] != "A" }
-    return true unless matches.present? && matches.all?
+  def at_least_one_domestic_abuse_with_applicant(_proceeding)
+    @proceedings.select { |h| h[:ccms_code].match(/DA\d{3}/) && h[:client_involvement_type] == "A" }.any?
   end
 
   def delegated_functions_on_any_proceeding(_proceeding)

--- a/db/seed_data/proceeding_type_merits_task.yml
+++ b/db/seed_data/proceeding_type_merits_task.yml
@@ -3,7 +3,7 @@
 #
 - ccms_code: "DA001"
   questions:
-  - always_unless_all_da_and_non_applicant:
+  - at_least_one_domestic_abuse_with_applicant:
     - latest_incident_details
   - opponent_details
   - statement_of_case
@@ -17,7 +17,7 @@
     - opponents_application
 - ccms_code: "DA002"
   questions:
-  - always_unless_all_da_and_non_applicant:
+  - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
   - opponent_details
   - statement_of_case
@@ -31,7 +31,7 @@
       - opponents_application
 - ccms_code: "DA003"
   questions:
-  - always_unless_all_da_and_non_applicant:
+  - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
   - opponent_details
   - statement_of_case
@@ -45,7 +45,7 @@
       - opponents_application
 - ccms_code: "DA004"
   questions:
-  - always_unless_all_da_and_non_applicant:
+  - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
   - opponent_details
   - statement_of_case
@@ -59,7 +59,7 @@
       - opponents_application
 - ccms_code: "DA005"
   questions:
-  - always_unless_all_da_and_non_applicant:
+  - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
   - opponent_details
   - statement_of_case
@@ -73,7 +73,7 @@
       - opponents_application
 - ccms_code: "DA006"
   questions:
-  - always_unless_all_da_and_non_applicant:
+  - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
   - opponent_details
   - statement_of_case
@@ -87,7 +87,7 @@
       - opponents_application
 - ccms_code: "DA007"
   questions:
-  - always_unless_all_da_and_non_applicant:
+  - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
   - opponent_details
   - statement_of_case
@@ -101,7 +101,7 @@
       - opponents_application
 - ccms_code: "DA020"
   questions:
-  - always_unless_all_da_and_non_applicant:
+  - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
   - opponent_details
   - statement_of_case

--- a/spec/services/questions_service_spec.rb
+++ b/spec/services/questions_service_spec.rb
@@ -78,6 +78,27 @@ RSpec.describe QuestionsService do
         expect(question_service).to eq expected_multiple_no_questions_response
       end
     end
+
+    context "when there are two DA proceedings with one as Applicant and one as Defendant" do
+      let(:proceedings) do
+        [
+          {
+            ccms_code: "DA001",
+            delegated_functions_used: false,
+            client_involvement_type: "A",
+          },
+          {
+            ccms_code: "DA005",
+            delegated_functions_used: false,
+            client_involvement_type: "D",
+          },
+        ]
+      end
+
+      it "returns valid response that includes the latest_incident_details questions" do
+        expect(question_service).to eq expected_latest_incident_details_response
+      end
+    end
   end
 
   context "when the request fails" do
@@ -100,6 +121,37 @@ RSpec.describe QuestionsService do
         expect(response[:errors]).to match [/The property '#\/proceedings\/0\/client_involvement_type' value "X" did not match one of the following values: .* in schema file/]
       end
     end
+  end
+
+  def expected_latest_incident_details_response
+    {
+      request_id:,
+      success: true,
+      application: {
+        tasks: {
+          "latest_incident_details" => [],
+          "client_denial_of_allegation" => [],
+          "client_offer_of_undertakings" => [],
+          "opponent_details" => [],
+          "statement_of_case" => [],
+        },
+      },
+      proceedings: [
+        {
+          ccms_code: "DA001",
+          tasks: {
+            "chances_of_success" => [],
+          },
+        },
+        {
+          ccms_code: "DA005",
+          tasks: {
+            "chances_of_success" => [],
+            "opponents_application" => [],
+          },
+        },
+      ],
+    }
   end
 
   def expected_da005_applicant_response


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3591)

This updates the logic and redefines the name for clarity 
It also updates the manual reference in the original merits task service to ensure it obeys the same exclusion rules


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
