### PR TITLE
Add `reason_for_new_application` to DA002 and DA006

### DIFF
--- a/db/seed_data/proceeding_type_merits_task.yml
+++ b/db/seed_data/proceeding_type_merits_task.yml
@@ -22,6 +22,7 @@
   - opponent_details
   - statement_of_case
   - chances_of_success
+  - reason_for_new_application
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
@@ -78,6 +79,7 @@
   - opponent_details
   - statement_of_case
   - chances_of_success
+  - reason_for_new_application
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings


### PR DESCRIPTION
Add `reason_for_new_application` merits task to DA002 and DA003

## What

[Relates to story](https://dsdmoj.atlassian.net/browse/AP-3489)

Confirmed with Dave that the following proceeding types
are applicable to the `reason_for_new_application`
(a.k.a `vary_order`) merits task question

DA002
DA006
SE007
SE008
SE015
SE016

but excluding A and E suffix versions (e.g. SE007A and SE007E)

I have added `proceeding_type_merits_task` join table records for
DA002 and DA003 in this PR as SE007 already added and SE008, SE015
and SE016 have not been added yet.

QUESTION: Should I add SE008, SE015 and SE016 too? unclear what other
question requirements they have though.



## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
