### PR TITLE
AP-3593: Split opponent questions

### DIFF
--- a/db/populators/merits_task_populator.rb
+++ b/db/populators/merits_task_populator.rb
@@ -1,7 +1,9 @@
 class MeritsTaskPopulator
   APPLICATION_MERITS_TASKS = %w[
     latest_incident_details
-    opponent_details
+    opponent_name
+    opponent_mental_capacity
+    domestic_abuse_summary
     children_application
     statement_of_case
     client_denial_of_allegation

--- a/db/seed_data/proceeding_type_merits_task.yml
+++ b/db/seed_data/proceeding_type_merits_task.yml
@@ -5,7 +5,10 @@
   questions:
   - at_least_one_domestic_abuse_with_applicant:
     - latest_incident_details
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
+  - at_least_one_domestic_abuse_with_applicant:
+    - domestic_abuse_summary
   - statement_of_case
   - chances_of_success
   - domestic_abuse_with_non_applicant:
@@ -19,7 +22,10 @@
   questions:
   - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
+  - at_least_one_domestic_abuse_with_applicant:
+    - domestic_abuse_summary
   - statement_of_case
   - chances_of_success
   - domestic_abuse_with_non_applicant:
@@ -33,7 +39,10 @@
   questions:
   - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
+  - at_least_one_domestic_abuse_with_applicant:
+    - domestic_abuse_summary
   - statement_of_case
   - chances_of_success
   - domestic_abuse_with_non_applicant:
@@ -47,7 +56,10 @@
   questions:
   - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
+  - at_least_one_domestic_abuse_with_applicant:
+    - domestic_abuse_summary
   - statement_of_case
   - chances_of_success
   - domestic_abuse_with_non_applicant:
@@ -61,7 +73,10 @@
   questions:
   - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
+  - at_least_one_domestic_abuse_with_applicant:
+    - domestic_abuse_summary
   - statement_of_case
   - chances_of_success
   - domestic_abuse_with_non_applicant:
@@ -75,7 +90,10 @@
   questions:
   - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
+  - at_least_one_domestic_abuse_with_applicant:
+    - domestic_abuse_summary
   - statement_of_case
   - chances_of_success
   - domestic_abuse_with_non_applicant:
@@ -89,7 +107,10 @@
   questions:
   - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
+  - at_least_one_domestic_abuse_with_applicant:
+    - domestic_abuse_summary
   - statement_of_case
   - chances_of_success
   - domestic_abuse_with_non_applicant:
@@ -103,7 +124,10 @@
   questions:
   - at_least_one_domestic_abuse_with_applicant:
       - latest_incident_details
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
+  - at_least_one_domestic_abuse_with_applicant:
+    - domestic_abuse_summary
   - statement_of_case
   - chances_of_success
   - domestic_abuse_with_non_applicant:
@@ -115,7 +139,8 @@
       - opponents_application
 - ccms_code: "SE003"
   questions:
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
   - statement_of_case
   - chances_of_success
   - children_application
@@ -130,7 +155,8 @@
       - opponents_application
 - ccms_code: "SE004"
   questions:
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
   - statement_of_case
   - chances_of_success
   - children_application
@@ -145,7 +171,8 @@
       - opponents_application
 - ccms_code: "SE007"
   questions:
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
   - statement_of_case
   - chances_of_success
   - children_application
@@ -159,7 +186,8 @@
       - opponents_application
 - ccms_code: "SE013"
   questions:
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
   - statement_of_case
   - chances_of_success
   - children_application
@@ -173,7 +201,8 @@
       - opponents_application
 - ccms_code: "SE014"
   questions:
-  - opponent_details
+  - opponent_name
+  - opponent_mental_capacity
   - statement_of_case
   - chances_of_success
   - children_application

--- a/spec/models/merits_task_spec.rb
+++ b/spec/models/merits_task_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MeritsTask do
   describe "#dependencies" do
     context "when the task has no dependencies" do
       it "returns and empty collection" do
-        task = described_class.find_by!(name: "opponent_details")
+        task = described_class.find_by!(name: "domestic_abuse_summary")
         expect(task.dependencies).to be_empty
       end
     end

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe ProceedingType do
       it "returns ordered list of all merits tasks" do
         rec = described_class.find_by(ccms_code: "DA003")
         tasks = rec.merits_tasks.pluck(:name)
-        expect(tasks).to eq %w[latest_incident_details opponent_details statement_of_case chances_of_success client_denial_of_allegation client_offer_of_undertakings nature_of_urgency opponents_application]
+        expect(tasks).to eq %w[latest_incident_details opponent_name opponent_mental_capacity domestic_abuse_summary statement_of_case chances_of_success client_denial_of_allegation client_offer_of_undertakings nature_of_urgency opponents_application]
       end
     end
 
     describe "application_tasks" do
       it "returns ordered list of application tasks only" do
         rec = described_class.find_by(ccms_code: "DA003")
-        expect(rec.application_tasks.map(&:name)).to eq %w[latest_incident_details opponent_details statement_of_case client_denial_of_allegation client_offer_of_undertakings nature_of_urgency]
+        expect(rec.application_tasks.map(&:name)).to eq %w[latest_incident_details opponent_name opponent_mental_capacity domestic_abuse_summary statement_of_case client_denial_of_allegation client_offer_of_undertakings nature_of_urgency]
       end
     end
 

--- a/spec/requests/civil_merits_questions_controller_swagger_spec.rb
+++ b/spec/requests/civil_merits_questions_controller_swagger_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe "civil_merits_questions", type: :request do
               application: {
                 tasks: {
                   latest_incident_details: [],
-                  opponent_details: [],
+                  opponent_name: [],
+                  opponent_mental_capacity: [],
+                  domestic_abuse_summary: [],
                   statement_of_case: [],
                   nature_of_urgency: [],
                 },
@@ -102,7 +104,8 @@ RSpec.describe "civil_merits_questions", type: :request do
               success: true,
               application: {
                 tasks: {
-                  opponent_details: [],
+                  opponent_name: [],
+                  opponent_mental_capacity: [],
                   statement_of_case: [],
                   client_denial_of_allegation: [],
                   client_offer_of_undertakings: [],

--- a/spec/requests/merits_tasks_controller_swagger_spec.rb
+++ b/spec/requests/merits_tasks_controller_swagger_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe "merits_tasks", type: :request do
             application: {
               tasks: {
                 "latest_incident_details" => [],
-                "opponent_details" => [],
+                "opponent_name" => [],
+                "opponent_mental_capacity" => [],
+                "domestic_abuse_summary" => [],
                 "statement_of_case" => [],
                 "children_application" => [],
                 "laspo" => [],

--- a/spec/services/merits_task_service_spec.rb
+++ b/spec/services/merits_task_service_spec.rb
@@ -56,7 +56,9 @@ RSpec.describe MeritsTaskService do
       application: {
         tasks: {
           "latest_incident_details" => [],
-          "opponent_details" => [],
+          "opponent_name" => [],
+          "opponent_mental_capacity" => [],
+          "domestic_abuse_summary" => [],
           "statement_of_case" => [],
         },
       },
@@ -79,7 +81,9 @@ RSpec.describe MeritsTaskService do
       application: {
         tasks: {
           "latest_incident_details" => [],
-          "opponent_details" => [],
+          "opponent_name" => [],
+          "opponent_mental_capacity" => [],
+          "domestic_abuse_summary" => [],
           "statement_of_case" => [],
           "children_application" => [],
           "laspo" => [],

--- a/spec/services/questions_service_spec.rb
+++ b/spec/services/questions_service_spec.rb
@@ -132,7 +132,9 @@ RSpec.describe QuestionsService do
           "latest_incident_details" => [],
           "client_denial_of_allegation" => [],
           "client_offer_of_undertakings" => [],
-          "opponent_details" => [],
+          "opponent_name" => [],
+          "opponent_mental_capacity" => [],
+          "domestic_abuse_summary" => [],
           "statement_of_case" => [],
         },
       },
@@ -161,7 +163,9 @@ RSpec.describe QuestionsService do
       application: {
         tasks: {
           "latest_incident_details" => [],
-          "opponent_details" => [],
+          "opponent_name" => [],
+          "opponent_mental_capacity" => [],
+          "domestic_abuse_summary" => [],
           "statement_of_case" => [],
           "nature_of_urgency" => [],
         },
@@ -183,7 +187,8 @@ RSpec.describe QuestionsService do
       success: true,
       application: {
         tasks: {
-          "opponent_details" => [],
+          "opponent_name" => [],
+          "opponent_mental_capacity" => [],
           "statement_of_case" => [],
           "client_denial_of_allegation" => [],
           "client_offer_of_undertakings" => [],
@@ -209,7 +214,9 @@ RSpec.describe QuestionsService do
       application: {
         tasks: {
           "latest_incident_details" => [],
-          "opponent_details" => [],
+          "opponent_name" => [],
+          "opponent_mental_capacity" => [],
+          "domestic_abuse_summary" => [],
           "statement_of_case" => [],
           "children_application" => [],
           "laspo" => [],
@@ -243,7 +250,9 @@ RSpec.describe QuestionsService do
       application: {
         tasks: {
           "latest_incident_details" => [],
-          "opponent_details" => [],
+          "opponent_name" => [],
+          "opponent_mental_capacity" => [],
+          "domestic_abuse_summary" => [],
           "statement_of_case" => [],
           "children_application" => [],
           "laspo" => [],

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -25,7 +25,9 @@ paths:
                     application:
                       tasks:
                         latest_incident_details: []
-                        opponent_details: []
+                        opponent_name: []
+                        opponent_mental_capacity: []
+                        domestic_abuse_summary: []
                         statement_of_case: []
                         nature_of_urgency: []
                     proceedings:
@@ -41,7 +43,8 @@ paths:
                     success: true
                     application:
                       tasks:
-                        opponent_details: []
+                        opponent_name: []
+                        opponent_mental_capacity: []
                         statement_of_case: []
                         client_denial_of_allegation: []
                         client_offer_of_undertakings: []
@@ -172,7 +175,9 @@ paths:
                     application:
                       tasks:
                         latest_incident_details: []
-                        opponent_details: []
+                        opponent_name: []
+                        opponent_mental_capacity: []
+                        domestic_abuse_summary: []
                         statement_of_case: []
                         children_application: []
                         laspo: []


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3593)

Update the seed data for merits tasks to replace opponent_deatils with three discrete questions
Ensure the task lists per proceeding type are updated to reflect the new options for DA and Child Section 8

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
