### PR TITLE
AP-3730: Update Nature of Urgency display rules

### DIFF
--- a/app/services/questions_service.rb
+++ b/app/services/questions_service.rb
@@ -79,6 +79,10 @@ private
     match.present?
   end
 
+  def delegated_functions_and_domestic_abuse_with_non_applicant(_proceeding)
+    @proceedings.select { |p| p[:ccms_code].match(/DA\d{3}/) && p[:client_involvement_type] != "A" && p[:delegated_functions_used].to_s == "true" }.any?
+  end
+
   def error_response
     {
       request_id: @request_id,

--- a/db/seed_data/proceeding_type_merits_task.yml
+++ b/db/seed_data/proceeding_type_merits_task.yml
@@ -14,7 +14,7 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
-  - delegated_functions_on_any_proceeding:
+  - delegated_functions_and_domestic_abuse_with_non_applicant:
     - nature_of_urgency
   - defendant_on_this_proceeding:
     - opponents_application
@@ -32,7 +32,7 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
-  - delegated_functions_on_any_proceeding:
+  - delegated_functions_and_domestic_abuse_with_non_applicant:
       - nature_of_urgency
   - defendant_on_this_proceeding:
       - opponents_application
@@ -49,7 +49,7 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
-  - delegated_functions_on_any_proceeding:
+  - delegated_functions_and_domestic_abuse_with_non_applicant:
       - nature_of_urgency
   - defendant_on_this_proceeding:
       - opponents_application
@@ -66,7 +66,7 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
-  - delegated_functions_on_any_proceeding:
+  - delegated_functions_and_domestic_abuse_with_non_applicant:
       - nature_of_urgency
   - defendant_on_this_proceeding:
       - opponents_application
@@ -83,7 +83,7 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
-  - delegated_functions_on_any_proceeding:
+  - delegated_functions_and_domestic_abuse_with_non_applicant:
       - nature_of_urgency
   - defendant_on_this_proceeding:
       - opponents_application
@@ -101,7 +101,7 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
-  - delegated_functions_on_any_proceeding:
+  - delegated_functions_and_domestic_abuse_with_non_applicant:
       - nature_of_urgency
   - defendant_on_this_proceeding:
       - opponents_application
@@ -118,7 +118,7 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
-  - delegated_functions_on_any_proceeding:
+  - delegated_functions_and_domestic_abuse_with_non_applicant:
       - nature_of_urgency
   - defendant_on_this_proceeding:
       - opponents_application
@@ -135,7 +135,7 @@
   - domestic_abuse_with_non_applicant:
     - client_denial_of_allegation
     - client_offer_of_undertakings
-  - delegated_functions_on_any_proceeding:
+  - delegated_functions_and_domestic_abuse_with_non_applicant:
       - nature_of_urgency
   - defendant_on_this_proceeding:
       - opponents_application

--- a/spec/requests/civil_merits_questions_controller_swagger_spec.rb
+++ b/spec/requests/civil_merits_questions_controller_swagger_spec.rb
@@ -66,7 +66,6 @@ RSpec.describe "civil_merits_questions", type: :request do
                   opponent_mental_capacity: [],
                   domestic_abuse_summary: [],
                   statement_of_case: [],
-                  nature_of_urgency: [],
                 },
               },
               proceedings: [

--- a/spec/services/questions_service_spec.rb
+++ b/spec/services/questions_service_spec.rb
@@ -167,7 +167,6 @@ RSpec.describe QuestionsService do
           "opponent_mental_capacity" => [],
           "domestic_abuse_summary" => [],
           "statement_of_case" => [],
-          "nature_of_urgency" => [],
         },
       },
       proceedings: [

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -29,7 +29,6 @@ paths:
                         opponent_mental_capacity: []
                         domestic_abuse_summary: []
                         statement_of_case: []
-                        nature_of_urgency: []
                     proceedings:
                     - ccms_code: DA001
                       tasks:


### PR DESCRIPTION


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3730)

Generate the question when the application contains -

* 1 or more domestic abuse proceedings only (no S8 proc's added) with delegated functions AND 1 or more proceedings are not 'applicant'
* 1 or more domestic abuse proceedings AND 1 or more S8 proceedings with delegated functions used
* 1 or more S8 proceedings only (no DA proc's added) with delegated functions

Do not generate the question when -

* None of the proceedings on the application have used delegated functions
* the applications contains 1 or more domestic abuse proceedings only (no S8 proc’s added) and the CIT on all of the proceedings is ‘applicant’


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
