### PR TITLE
Rename matter type names to align with Apply

### DIFF
--- a/app/models/matter_type.rb
+++ b/app/models/matter_type.rb
@@ -1,9 +1,9 @@
 class MatterType < ApplicationRecord
   def self.domestic_abuse
-    find_by(name: "Domestic abuse")
+    find_by(name: "Domestic Abuse")
   end
 
   def self.section8
-    find_by(name: "Children - section 8")
+    find_by(name: "Section 8 orders")
   end
 end

--- a/db/migrate/20230104094258_rename_matter_types.rb
+++ b/db/migrate/20230104094258_rename_matter_types.rb
@@ -1,0 +1,11 @@
+class RenameMatterTypes < ActiveRecord::Migration[7.0]
+  def up
+    MatterType.where(name: "Domestic abuse").update_all(name: "Domestic Abuse")
+    MatterType.where(name: "Children - section 8").update_all(name: "Section 8 orders")
+  end
+
+  def down
+    MatterType.where(name: "Domestic Abuse").update_all(name: "Domestic abuse")
+    MatterType.where(name: "Section 8 orders").update_all(name: "Children - section 8")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_28_165100) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_04_094258) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/seed_data/matter_types.yml
+++ b/db/seed_data/matter_types.yml
@@ -1,15 +1,15 @@
 ---
 # this file lists the matter types
 #
-# - - Domestic abuse      - name of the matter type
+# - - Domestic Abuse      - name of the matter type
 #  - matter_code          - This code is required for the CCMS Submission and will be needed by Apply
 #  - category_of_law      - This is required proceeding_type searches
 #  - category_of_law_code - This code is required for the CCMS Submission and will be needed by Apply
-- - Domestic abuse # TODO: Capitalise `Abuse` that is how it is used in Apply
+- - Domestic Abuse
   - MINJN
   - Family
   - MAT
-- - Children - section 8 # TODO: Change to `Section 8 orders` as it appears in Apply?
+- - Section 8 orders
   - KSEC8
   - Family
   - MAT

--- a/db/seed_data/threshold_waivers.json
+++ b/db/seed_data/threshold_waivers.json
@@ -1,7 +1,7 @@
 {
   "seed_data": [
     {
-      "matter_type": "Domestic abuse",
+      "matter_type": "Domestic Abuse",
       "client_involvement_type": "A",
       "gross_income_upper": true,
       "disposable_income_upper":true,

--- a/spec/models/matter_type_spec.rb
+++ b/spec/models/matter_type_spec.rb
@@ -4,13 +4,13 @@ RSpec.describe MatterType do
   describe "finders" do
     describe ".domestic_abuse" do
       it "returns the domestic abuse record" do
-        expect(described_class.domestic_abuse.name).to eq "Domestic abuse"
+        expect(described_class.domestic_abuse.name).to eq "Domestic Abuse"
       end
     end
 
     describe ".section8" do
       it "returns the section8 record" do
-        expect(described_class.section8.name).to eq "Children - section 8"
+        expect(described_class.section8.name).to eq "Section 8 orders"
       end
     end
   end

--- a/spec/requests/proceeding_types/searches_controller_swagger_spec.rb
+++ b/spec/requests/proceeding_types/searches_controller_swagger_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "proceeding_types/searches_controller", type: :request do
                     description: "to be represented on an application for an occupation order.",
                     full_s8_only: false,
                     ccms_category_law: "Family",
-                    ccms_matter: "Domestic abuse",
+                    ccms_matter: "Domestic Abuse",
                   },
                 ],
             }
@@ -132,7 +132,7 @@ RSpec.describe "proceeding_types/searches_controller", type: :request do
                     description: "to be represented on an application for an injunction, order or declaration under the inherent jurisdiction of the court.",
                     full_s8_only: false,
                     ccms_category_law: "Family",
-                    ccms_matter: "Domestic abuse",
+                    ccms_matter: "Domestic Abuse",
                   },
                   {
                     meaning: "Harassment - injunction",
@@ -140,7 +140,7 @@ RSpec.describe "proceeding_types/searches_controller", type: :request do
                     description: "to be represented in an action for an injunction under section 3 Protection from Harassment Act 1997.",
                     full_s8_only: false,
                     ccms_category_law: "Family",
-                    ccms_matter: "Domestic abuse",
+                    ccms_matter: "Domestic Abuse",
                   },
                   {
                     meaning: "Non-molestation order",
@@ -148,7 +148,7 @@ RSpec.describe "proceeding_types/searches_controller", type: :request do
                     description: "to be represented on an application for a non-molestation order.",
                     full_s8_only: false,
                     ccms_category_law: "Family",
-                    ccms_matter: "Domestic abuse",
+                    ccms_matter: "Domestic Abuse",
                   },
                 ],
             }

--- a/spec/requests/proceeding_types/threshold_waivers_controller_swagger_spec.rb
+++ b/spec/requests/proceeding_types/threshold_waivers_controller_swagger_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "proceeding_types/threshold_waivers", type: :request do
                 gross_income_upper: true,
                 disposable_income_upper: true,
                 capital_upper: true,
-                matter_type: "Domestic abuse",
+                matter_type: "Domestic Abuse",
               },
               {
                 ccms_code: "SE004",
@@ -54,7 +54,7 @@ RSpec.describe "proceeding_types/threshold_waivers", type: :request do
                 gross_income_upper: false,
                 disposable_income_upper: false,
                 capital_upper: false,
-                matter_type: "Children - section 8",
+                matter_type: "Section 8 orders",
               },
               {
                 ccms_code: "SE013",
@@ -62,7 +62,7 @@ RSpec.describe "proceeding_types/threshold_waivers", type: :request do
                 gross_income_upper: false,
                 disposable_income_upper: false,
                 capital_upper: false,
-                matter_type: "Children - section 8",
+                matter_type: "Section 8 orders",
               },
             ],
           }

--- a/spec/requests/proceeding_types_controller_swagger_spec.rb
+++ b/spec/requests/proceeding_types_controller_swagger_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "proceeding_types", type: :request do
             description: "to be represented on an application for a prohibited steps order.",
             full_s8_only: false,
             ccms_category_law: "Family",
-            ccms_matter: "Children - section 8",
+            ccms_matter: "Section 8 orders",
             cost_limitations: {
               substantive: {
                 start_date: "1970-01-01",

--- a/spec/requests/threshold_waivers_controller_swagger_spec.rb
+++ b/spec/requests/threshold_waivers_controller_swagger_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "threshold_waivers", type: :request do
                 gross_income_upper: true,
                 disposable_income_upper: true,
                 capital_upper: true,
-                matter_type: "Domestic abuse",
+                matter_type: "Domestic Abuse",
               },
               {
                 ccms_code: "SE004",
@@ -80,7 +80,7 @@ RSpec.describe "threshold_waivers", type: :request do
                 gross_income_upper: false,
                 disposable_income_upper: false,
                 capital_upper: false,
-                matter_type: "Children - section 8",
+                matter_type: "Section 8 orders",
               },
             ],
           }

--- a/spec/services/proceeding_type_service_spec.rb
+++ b/spec/services/proceeding_type_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ProceedingTypeService do
                    " section 3 Protection from Harassment Act 1997.",
       full_s8_only: false,
       ccms_category_law: "Family",
-      ccms_matter: "Domestic abuse",
+      ccms_matter: "Domestic Abuse",
       cost_limitations: {
         substantive: {
           start_date: "1970-01-01",
@@ -115,7 +115,7 @@ RSpec.describe ProceedingTypeService do
       description: "to be represented on an application for a prohibited steps order.",
       full_s8_only: false,
       ccms_category_law: "Family",
-      ccms_matter: "Children - section 8",
+      ccms_matter: "Section 8 orders",
       cost_limitations: {
         substantive: {
           start_date: "1970-01-01",
@@ -168,7 +168,7 @@ RSpec.describe ProceedingTypeService do
       description: "to be represented on an application for a prohibited steps order.  Appeals only.",
       full_s8_only: true,
       ccms_category_law: "Family",
-      ccms_matter: "Children - section 8",
+      ccms_matter: "Section 8 orders",
       cost_limitations: {
         substantive: {
           start_date: "1970-01-01",

--- a/spec/services/threshold_waiver_service_spec.rb
+++ b/spec/services/threshold_waiver_service_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe ThresholdWaiverService do
             capital_upper: true,
             disposable_income_upper: true,
             gross_income_upper: true,
-            matter_type: "Domestic abuse",
+            matter_type: "Domestic Abuse",
           },
         ],
       }
@@ -128,7 +128,7 @@ RSpec.describe ThresholdWaiverService do
             capital_upper: true,
             disposable_income_upper: true,
             gross_income_upper: true,
-            matter_type: "Domestic abuse",
+            matter_type: "Domestic Abuse",
           },
           {
             ccms_code: "SE003",
@@ -137,7 +137,7 @@ RSpec.describe ThresholdWaiverService do
             capital_upper: false,
             disposable_income_upper: false,
             gross_income_upper: false,
-            matter_type: "Children - section 8",
+            matter_type: "Section 8 orders",
           },
           {
             ccms_code: "SE013",
@@ -146,7 +146,7 @@ RSpec.describe ThresholdWaiverService do
             capital_upper: false,
             disposable_income_upper: false,
             gross_income_upper: false,
-            matter_type: "Children - section 8",
+            matter_type: "Section 8 orders",
           },
         ],
       }
@@ -211,7 +211,7 @@ RSpec.describe ThresholdWaiverService do
             capital_upper: true,
             disposable_income_upper: true,
             gross_income_upper: true,
-            matter_type: "Domestic abuse",
+            matter_type: "Domestic Abuse",
           },
         ],
       }
@@ -228,7 +228,7 @@ RSpec.describe ThresholdWaiverService do
             capital_upper: true,
             disposable_income_upper: true,
             gross_income_upper: true,
-            matter_type: "Domestic abuse",
+            matter_type: "Domestic Abuse",
           },
           {
             ccms_code: "SE003",
@@ -236,7 +236,7 @@ RSpec.describe ThresholdWaiverService do
             capital_upper: false,
             disposable_income_upper: false,
             gross_income_upper: false,
-            matter_type: "Children - section 8",
+            matter_type: "Section 8 orders",
           },
           {
             ccms_code: "SE013",
@@ -244,7 +244,7 @@ RSpec.describe ThresholdWaiverService do
             capital_upper: false,
             disposable_income_upper: false,
             gross_income_upper: false,
-            matter_type: "Children - section 8",
+            matter_type: "Section 8 orders",
           },
         ],
       }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -482,7 +482,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: MINJN
-                    ccms_matter: Domestic abuse
+                    ccms_matter: Domestic Abuse
                   - ccms_code: DA002
                     meaning: Variation or discharge under section 5 protection from
                       harassment act 1997
@@ -493,7 +493,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: MINJN
-                    ccms_matter: Domestic abuse
+                    ccms_matter: Domestic Abuse
                   - ccms_code: DA003
                     meaning: Harassment - injunction
                     description: to be represented in an action for an injunction
@@ -501,7 +501,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: MINJN
-                    ccms_matter: Domestic abuse
+                    ccms_matter: Domestic Abuse
                   - ccms_code: DA004
                     meaning: Non-molestation order
                     description: to be represented on an application for a non-molestation
@@ -509,7 +509,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: MINJN
-                    ccms_matter: Domestic abuse
+                    ccms_matter: Domestic Abuse
                   - ccms_code: DA005
                     meaning: Occupation order
                     description: to be represented on an application for an occupation
@@ -517,7 +517,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: MINJN
-                    ccms_matter: Domestic abuse
+                    ccms_matter: Domestic Abuse
                   - ccms_code: DA006
                     meaning: Extend, variation or discharge - Part IV
                     description: to be represented on an application to extend, vary
@@ -525,7 +525,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: MINJN
-                    ccms_matter: Domestic abuse
+                    ccms_matter: Domestic Abuse
                   - ccms_code: DA007
                     meaning: Forced marriage protection order
                     description: to be represented on an application for a forced
@@ -533,7 +533,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: MINJN
-                    ccms_matter: Domestic abuse
+                    ccms_matter: Domestic Abuse
                   - ccms_code: DA020
                     meaning: FGM Protection Order
                     description: To be represented on an application for a Female
@@ -542,7 +542,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: MINJN
-                    ccms_matter: Domestic abuse
+                    ccms_matter: Domestic Abuse
                   - ccms_code: SE003
                     meaning: Prohibited steps order
                     description: to be represented on an application for a prohibited
@@ -550,7 +550,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE003A
                     meaning: Prohibited Steps Order-Appeal-S8
                     description: to be represented on an application for a prohibited
@@ -558,7 +558,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE003E
                     meaning: Prohibited Steps Order-Enforcement-S8
                     description: to be represented on an application for a prohibited
@@ -566,7 +566,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE004
                     meaning: Specific Issue Order
                     description: to be represented on an application for a specific
@@ -574,7 +574,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE004A
                     meaning: Specific Issue Order-Appeal-S8
                     description: to be represented on an application for a specific
@@ -582,7 +582,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE004E
                     meaning: Specific Issue Order-Enforcement-S8
                     description: to be represented on an application for a specific
@@ -590,7 +590,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE007
                     meaning: Vary/Discharge Prohib Steps Order-S8
                     description: to be represented on an application to vary or discharge
@@ -598,7 +598,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE007A
                     meaning: Vary/Discharge Prohib Steps Order-Appeal-S8
                     description: to be represented on an application to vary or discharge
@@ -606,7 +606,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE007E
                     meaning: Vary/Discharge Prohib Steps Order-Enforcement-S8
                     description: to be represented on an application to vary or discharge
@@ -614,7 +614,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE008
                     meaning: Vary/Discharge Specific Issues Ord-S8
                     description: to be represented on an application to vary or discharge
@@ -622,7 +622,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE008A
                     meaning: Vary/Discharge Specific Issues Ord-Appeal-S8
                     description: to be represented on an application to vary or discharge
@@ -630,7 +630,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE008E
                     meaning: Vary/Discharge Specific Issues Ord-Enforcement-S8
                     description: to be represented on an application to vary or discharge
@@ -638,7 +638,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE013
                     meaning: Child arrangements order (contact)
                     description: to be represented on an application for a child arrangements
@@ -646,7 +646,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE013A
                     meaning: CAO contact-Appeal
                     description: to be represented on an application for a child arrangements
@@ -654,7 +654,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE013E
                     meaning: CAO contact-Enforcement
                     description: to be represented on an application for a child arrangements
@@ -662,7 +662,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE014
                     meaning: Child arrangements order (residence)
                     description: to be represented on an application for a child arrangements
@@ -670,7 +670,7 @@ paths:
                     full_s8_only: false
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE014A
                     meaning: CAO residence-Appeal
                     description: to be represented on an application for a child arrangements
@@ -678,7 +678,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE014E
                     meaning: CAO residence-Enforcement
                     description: to be represented on an application for a child arrangements
@@ -686,7 +686,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE015
                     meaning: Vary CAO contact
                     description: to be represented on an application to vary/discharge
@@ -694,7 +694,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE015A
                     meaning: Vary CAO contact-Appeal
                     description: to be represented on an application to vary/discharge
@@ -703,7 +703,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE015E
                     meaning: Vary CAO contact-Enforcement
                     description: to be represented on an application to vary/discharge
@@ -712,7 +712,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE016
                     meaning: Vary CAO residence
                     description: to be represented on an application to vary or discharge
@@ -720,7 +720,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE016A
                     meaning: Vary CAO residence-Appeal
                     description: to be represented on an application to vary or discharge
@@ -729,7 +729,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE016E
                     meaning: Vary CAO residence-Enforcement
                     description: to be represented on an application to vary or discharge
@@ -738,7 +738,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE095
                     meaning: Enforcement order 11J-S8
                     description: to be represented on an application for an enforcement
@@ -746,7 +746,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE095A
                     meaning: Enforcement order-Appeal-S8
                     description: to be represented on an application for an enforcement
@@ -754,7 +754,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE096E
                     meaning: Enforcement order+c’tal-S8
                     description: to be represented on an application for committal
@@ -763,7 +763,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE097
                     meaning: Revocation enforcement-S8
                     description: to be represented on an application for the revocation
@@ -772,7 +772,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE097A
                     meaning: Revocation enforcement-Appeal-S8
                     description: to be represented on an application for the revocation
@@ -781,7 +781,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE099E
                     meaning: Amd enforcement-breach-S8
                     description: to be represented on an application, following breach,
@@ -791,7 +791,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE100E
                     meaning: Breach enforcement-S8
                     description: to be represented on an application, following breach,
@@ -801,7 +801,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE101A
                     meaning: Compensation-Appeal-S8
                     description: to be represented on an application for compensation
@@ -810,7 +810,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   - ccms_code: SE101E
                     meaning: Compensation-Enforcement-S8
                     description: to be represented on an application for compensation
@@ -819,7 +819,7 @@ paths:
                     full_s8_only: true
                     ccms_category_law: Family
                     ccms_matter_code: KSEC8
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                   summary: Successful request
                   description: Returns an array of all proceeding types with summary
                     data
@@ -849,7 +849,7 @@ paths:
                         order.
                       full_s8_only: false
                       ccms_category_law: Family
-                      ccms_matter: Domestic abuse
+                      ccms_matter: Domestic Abuse
                   summary: Single success
                   description: When a user requests a single match it is returned
                 no_matches_found:
@@ -871,21 +871,21 @@ paths:
                         court.
                       full_s8_only: false
                       ccms_category_law: Family
-                      ccms_matter: Domestic abuse
+                      ccms_matter: Domestic Abuse
                     - meaning: Harassment - injunction
                       ccms_code: DA003
                       description: to be represented in an action for an injunction
                         under section 3 Protection from Harassment Act 1997.
                       full_s8_only: false
                       ccms_category_law: Family
-                      ccms_matter: Domestic abuse
+                      ccms_matter: Domestic Abuse
                     - meaning: Non-molestation order
                       ccms_code: DA004
                       description: to be represented on an application for a non-molestation
                         order.
                       full_s8_only: false
                       ccms_category_law: Family
-                      ccms_matter: Domestic abuse
+                      ccms_matter: Domestic Abuse
                   summary: Multiple results
                   description: When searching for a description that matches multiple
                     proceedings they are all returned
@@ -956,19 +956,19 @@ paths:
                       gross_income_upper: true
                       disposable_income_upper: true
                       capital_upper: true
-                      matter_type: Domestic abuse
+                      matter_type: Domestic Abuse
                     - ccms_code: SE004
                       full_s8_only: false
                       gross_income_upper: false
                       disposable_income_upper: false
                       capital_upper: false
-                      matter_type: Children - section 8
+                      matter_type: Section 8 orders
                     - ccms_code: SE013
                       full_s8_only: false
                       gross_income_upper: false
                       disposable_income_upper: false
                       capital_upper: false
-                      matter_type: Children - section 8
+                      matter_type: Section 8 orders
                   summary: Successful request
                   description: Returns the details of threshold waivers for specified
                     proceeding types identified by an array of CCMS codes
@@ -1042,7 +1042,7 @@ paths:
                       steps order.
                     full_s8_only: false
                     ccms_category_law: Family
-                    ccms_matter: Children - section 8
+                    ccms_matter: Section 8 orders
                     cost_limitations:
                       substantive:
                         start_date: '1970-01-01'
@@ -1120,14 +1120,14 @@ paths:
                       gross_income_upper: true
                       disposable_income_upper: true
                       capital_upper: true
-                      matter_type: Domestic abuse
+                      matter_type: Domestic Abuse
                     - ccms_code: SE004
                       full_s8_only: false
                       client_involvement_type: D
                       gross_income_upper: false
                       disposable_income_upper: false
                       capital_upper: false
-                      matter_type: Children - section 8
+                      matter_type: Section 8 orders
                   summary: Successful request
                   description: Return details of threshold waivers for specified proceeding
                     type and client involvement type pairs identified by CCMS codes


### PR DESCRIPTION
This renames the two matter type names to be consistent with their naming in Apply (as suggested by the now deleted TODO comments).

[Link to story](https://dsdmoj.atlassian.net/browse/AP-3732)

[AP-3732]: https://dsdmoj.atlassian.net/browse/AP-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ