### PR TITLE
Remove TODO comment

### DIFF
--- a/db/seed_data/matter_types.yml
+++ b/db/seed_data/matter_types.yml
@@ -5,11 +5,11 @@
 #  - matter_code          - This code is required for the CCMS Submission and will be needed by Apply
 #  - category_of_law      - This is required proceeding_type searches
 #  - category_of_law_code - This code is required for the CCMS Submission and will be needed by Apply
-- - Domestic abuse # TODO: Capitalise `Abuse` that is how it is used in Apply
+- - Domestic abuse
   - MINJN
   - Family
   - MAT
-- - Children - section 8 # TODO: Change to `Section 8 orders` as it appears in Apply?
+- - Children - section 8
   - KSEC8
   - Family
   - MAT


### PR DESCRIPTION
This removes TODO comments suggesting matter type seed data names are renamed, and replaces them with a ticket to track the work in JIRA.

[Link to new story](https://dsdmoj.atlassian.net/browse/AP-3732)

[AP-3732]: https://dsdmoj.atlassian.net/browse/AP-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ