### PR TITLE
AP-3749: Update s8 substantive cost limit seeding

### DIFF
--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -58,6 +58,7 @@ class ProceedingType < ApplicationRecord
 
   def self.populate
     ProceedingTypePopulator.call
+    DefaultCostLimitationPopulator.call
     refresh_text_searchable
   end
 

--- a/app/services/proceeding_type_populator.rb
+++ b/app/services/proceeding_type_populator.rb
@@ -7,7 +7,6 @@ class ProceedingTypePopulator
 
   def call
     seed_data.each { |seed_hash| populate(seed_hash) }
-    populate_default_cost_limitations
   end
 
 private
@@ -29,23 +28,5 @@ private
 
   def seed_data
     @seed_data ||= YAML.load_file(DATA_FILE)
-  end
-
-  def populate_default_cost_limitations
-    pts = ProceedingType.all
-    pts.each { |pt| add_cost_limitations(pt) }
-  end
-
-  def add_cost_limitations(proceeding_type)
-    find_or_create_dcl(proceeding_type:, cost_type: "substantive", start_date: Date.parse("1970-01-01"), value: 25_000.0)
-    find_or_create_dcl(proceeding_type:, cost_type: "delegated_functions", start_date: Date.parse("1970-01-01"), value: 1_350.0)
-    find_or_create_dcl(proceeding_type:, cost_type: "delegated_functions", start_date: Date.parse("2021-09-13"), value: 2_250.0)
-  end
-
-  def find_or_create_dcl(proceeding_type:, cost_type:, start_date:, value:)
-    dcl = DefaultCostLimitation.find_by(proceeding_type:, cost_type:, start_date:, value:)
-    return if dcl.present?
-
-    DefaultCostLimitation.create!(proceeding_type:, cost_type:, start_date:, value:)
   end
 end

--- a/db/populators/default_cost_limitation_populator.rb
+++ b/db/populators/default_cost_limitation_populator.rb
@@ -1,0 +1,47 @@
+class DefaultCostLimitationPopulator
+  DATA_FILE = Rails.root.join("db/seed_data/default_cost_limitations.yml").freeze
+
+  def self.call
+    new.call
+  end
+
+  def call
+    DefaultCostLimitation.destroy_all
+    populate_default_cost_limitations
+  end
+
+private
+
+  def seed_data
+    @seed_data ||= YAML.load_file(DATA_FILE)
+  end
+
+  def populate_default_cost_limitations
+    pts = ProceedingType.all
+    pts.each { |pt| add_cost_limitations(pt) }
+  end
+
+  def add_cost_limitations(proceeding_type)
+    proc_type_ccms_code = proceeding_type.ccms_code
+    dcl_values = build_dcl_hash_for(proc_type_ccms_code)
+    dcl_values.each_key { |cost_type| create_records_for(proceeding_type, dcl_values, cost_type) }
+  end
+
+  def create_records_for(proceeding_type, dcl_values, cost_type)
+    dcl_values[cost_type].each do |start_date, value|
+      DefaultCostLimitation.create!(proceeding_type:, cost_type:, start_date:, value:)
+    end
+  end
+
+  def build_dcl_hash_for(proc_type_ccms_code)
+    source = default_dcl
+    specific_hash = seed_data[proc_type_ccms_code]
+    return source if specific_hash.nil?
+
+    source.merge(specific_hash)
+  end
+
+  def default_dcl
+    @default_dcl ||= seed_data["default"]
+  end
+end

--- a/db/seed_data/default_cost_limitations.yml
+++ b/db/seed_data/default_cost_limitations.yml
@@ -1,0 +1,40 @@
+---
+default:
+  substantive:
+    '1970-01-01': 25_000
+  delegated_functions:
+    '1970-01-01': 1_350
+    '2021-09-13': 2_250
+SE003A:
+  substantive:
+    '1970-01-01': 5_000
+SE004A:
+  substantive:
+    '1970-01-01': 5_000
+SE007A:
+  substantive:
+    '1970-01-01': 5_000
+SE008A:
+  substantive:
+    '1970-01-01': 5_000
+SE013A:
+  substantive:
+    '1970-01-01': 5_000
+SE014A:
+  substantive:
+    '1970-01-01': 5_000
+SE015A:
+  substantive:
+    '1970-01-01': 5_000
+SE016A:
+  substantive:
+    '1970-01-01': 5_000
+SE095A:
+  substantive:
+    '1970-01-01': 5_000
+SE097A:
+  substantive:
+    '1970-01-01': 5_000
+SE101A:
+  substantive:
+    '1970-01-01': 5_000

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ProceedingType do
     end
 
     context "with cost limitations" do
-      let(:pt) { described_class.first }
+      let(:pt) { described_class.find_by(ccms_code: "DA001") }
 
       around do |example|
         travel_to run_date

--- a/spec/populators/default_cost_limitation_populator_spec.rb
+++ b/spec/populators/default_cost_limitation_populator_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe DefaultCostLimitationPopulator do
+  it { expect(described_class).to respond_to(:call) }
+  it { expect(described_class.new).to respond_to(:call) }
+
+  describe ".call" do
+    subject(:call) { described_class.call }
+
+    let(:dcl_keys) { YAML.load_file(Rails.root.join("db/seed_data/default_cost_limitations.yml")) }
+    let(:seed_count) { dcl_keys.map { |p| p["questions"].map { |q| q.is_a?(Hash) ? q.values.flatten.count : 1 }.sum }.sum }
+
+    it "deletes all existing records" do
+      expect(DefaultCostLimitation).to receive(:destroy_all)
+      call
+    end
+
+    it "creates new records" do
+      # Note this tests for 3 records per proceeding type as, at the time of writing, each
+      # proceeding type should have a single, substantive, DCL and two emergency DCLs
+      # This will change if new proceedings are added or additional date changes are added to emergency or substantive grants
+      call
+      expect(DefaultCostLimitation.count).to eq 123
+    end
+
+    context "when a non-default value is set" do
+      let(:se097a) { DefaultCostLimitation.find_by(proceeding_type: ProceedingType.find_by(ccms_code: "SE097A"), cost_type: "substantive") }
+
+      before { call }
+
+      it { expect(se097a.value).to eq 5_000 }
+    end
+  end
+end

--- a/spec/services/proceeding_type_service_spec.rb
+++ b/spec/services/proceeding_type_service_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe ProceedingTypeService do
       cost_limitations: {
         substantive: {
           start_date: "1970-01-01",
-          value: "25000.0",
+          value: "5000.0",
         },
         delegated_functions: {
           start_date: "2021-09-13",


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

Create a new populator for default cost limitations.
It reads from a new seed file and creates default cost limits with a default set of values that get overridden if a separate yaml
block exists for a given proceeding type

It removes the old seeding method that was included in ProceedingTypePopulator

It tidies up some existing tests that were failing because the default values changed

This is a new method of seeding (one default set and then overrides) so I'm interested to see what people think.
I did it this way to remove some of the repetition in the other seed files

Happy to discuss, pair and update if needed

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
