### PR TITLE
AP-4298: Use short lived credentials (IRSA) for ECR push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,9 @@
 version: 2.1
 
 orbs:
+  aws-cli: circleci/aws-cli@4.0.0
   slack: circleci/slack@4.5.2
+
 executors:
   basic-executor:
     docker:
@@ -37,27 +39,6 @@ executors:
     resource_class: small
 
 references:
-  build_docker_image: &build_docker_image
-    run:
-      name: Build docker image
-      command: |
-        docker build \
-        --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
-        --build-arg BUILD_TAG="app-${CIRCLE_SHA1}" \
-        --build-arg APP_BRANCH=${CIRCLE_BRANCH} \
-        -t app .
-  push_to_ecr: &push_to_ecr
-    run:
-      name: Push image to ecr repo
-      command: |
-        aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${ECR_ENDPOINT}
-        docker tag app "${ECR_ENDPOINT}/laa-apply-for-legal-aid/legal-framework-api-uat-ecr:${CIRCLE_SHA1}"
-        docker push "${ECR_ENDPOINT}/laa-apply-for-legal-aid/legal-framework-api-uat-ecr:${CIRCLE_SHA1}"
-
-        if [ "${CIRCLE_BRANCH}" == "main" ]; then
-          docker tag app "${ECR_ENDPOINT}/laa-apply-for-legal-aid/legal-framework-api-uat-ecr:latest"
-          docker push "${ECR_ENDPOINT}/laa-apply-for-legal-aid/legal-framework-api-uat-ecr:latest"
-        fi
   authenticate_k8s_live: &authenticate_k8s_live
     run:
       name: Authenticate with cluster
@@ -102,6 +83,33 @@ references:
       command: |
         bundle exec rake db:create db:schema:load
         bundle exec rake db:migrate
+
+commands:
+  build-and-push-to-ecr:
+    description: Build and push image to ECR repository
+    steps:
+      - run:
+          name: Build docker image
+          command: |
+            docker build \
+            --build-arg BUILD_DATE=$(date +%Y-%m-%dT%H:%M:%S%z) \
+            --build-arg BUILD_TAG="app-${CIRCLE_SHA1}" \
+            --build-arg APP_BRANCH=${CIRCLE_BRANCH} \
+            -t app .
+      - aws-cli/setup:
+          role_arn: $ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run:
+          name: Push image to ECR repository
+          command: |
+            aws ecr get-login-password --region ${ECR_REGION} | docker login --username AWS --password-stdin ${ECR_REGISTRY}
+            docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
+            docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${CIRCLE_SHA1}"
+
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+              docker tag app "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+              docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:latest"
+            fi
 
 jobs:
   lint_checks:
@@ -155,8 +163,7 @@ jobs:
       - setup_remote_docker:
           version: 20.10.11
       - *decrypt_secrets
-      - *build_docker_image
-      - *push_to_ecr
+      - build-and-push-to-ecr
   deploy_uat: &deploy_uat
     executor: cloud-platform-executor
     steps:
@@ -188,7 +195,7 @@ jobs:
                           --install --wait \
                           --namespace=${K8S_NAMESPACE} \
                           --values ./deploy/helm/values-staging.yaml \
-                          --set image.repository="$ECR_ENDPOINT/laa-apply-for-legal-aid/legal-framework-api-uat-ecr" \
+                          --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
                           --set image.tag="${CIRCLE_SHA1}"
   deploy_production:
     executor: cloud-platform-executor
@@ -205,7 +212,7 @@ jobs:
                         --install --wait \
                         --namespace=${K8S_NAMESPACE} \
                         --values ./deploy/helm/values-production.yaml \
-                        --set image.repository="$ECR_ENDPOINT/laa-apply-for-legal-aid/legal-framework-api-uat-ecr" \
+                        --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
                         --set image.tag="${CIRCLE_SHA1}"
 
   delete_dependabot_deployment:

--- a/bin/delete_ecr_images
+++ b/bin/delete_ecr_images
@@ -2,7 +2,7 @@
 require 'json'
 require 'date'
 
-repo = 'laa-apply-for-legal-aid/legal-framework-api-uat-ecr'
+repo = $ECR_REPOSITORY
 delete_if_older_than = 10 # days
 
 puts 'Identifying images to delete'

--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 deploy() {
-  IMG_REPO="$ECR_ENDPOINT/laa-apply-for-legal-aid/legal-framework-api-uat-ecr"
+  IMG_REPO="${ECR_REGISTRY}/${ECR_REPOSITORY}"
   RELEASE_NAME=$(echo $CIRCLE_BRANCH | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-30 | sed 's/-$//')
   RELEASE_HOST="$RELEASE_NAME-legal-framework-uat.cloud-platform.service.justice.gov.uk"
   IDENTIFIER="$RELEASE_NAME-legal-framework-api-legal-framework-api-uat-green"


### PR DESCRIPTION
## What
Use short lived credentials (IRSA) for ECR push

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4298)

Following the guide from cloud platform [migrating to short lived credentials for CircleCi](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#migrating-to-short-lived-credentials-for-circleci).

See related PR for [Adding CircleCI OIDC provider](https://github.com/ministryofjustice/cloud-platform-environments/pull/14437)

Note, since the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
and `AWS_DEFAULT_REGION` still exist in the circleci environment
variables it is unclear whether they are being used.

A test on Hmrc Interface was successfull in this [CircleCI run](https://app.circleci.com/pipelines/github/ministryofjustice/laa-hmrc-interface-service-api/5609/workflows/e77a7dc6-750f-45d9-aea5-4281f687f981/jobs/22838) so we can assume it
will work here too.

Once ECR delete scripts are replaced with ECR lifecycle we policy we can
delete the long lived credentials.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
