### PR TITLE
AP-4281: Add opponent organisation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An API for checking the required information for legal aid applications
 The API is documented at /api-docs.
 
 The documentation is generated with swagger for ruby [RSWAG](https://github.com/rswag/rswag#readme) from specs
-in the `spec/requests/swagger_docs` folder and allows real requests to be made.
+in the `spec/requests` folder and allows real requests to be made.
 
 If changes are made to files in this directory, regenerate the swagger documentation by executing `NOCOVERAGE=true rake rswag`.
 

--- a/app/controllers/organisation_types_controller.rb
+++ b/app/controllers/organisation_types_controller.rb
@@ -1,0 +1,8 @@
+class OrganisationTypesController < ApplicationController
+  # TODO: are we parsing and reparsing JSON unnecssarily here
+  # if ap_json returns as_json instead then we do not have to re-parse it
+  def index
+    result = OrganisationType.order(:description).map { |o| o.api_json }
+    render json: result, status: :ok
+  end
+end

--- a/app/controllers/organisation_types_controller.rb
+++ b/app/controllers/organisation_types_controller.rb
@@ -1,8 +1,6 @@
 class OrganisationTypesController < ApplicationController
-  # TODO: are we parsing and reparsing JSON unnecssarily here
-  # if ap_json returns as_json instead then we do not have to re-parse it
   def index
-    result = OrganisationType.order(:description).map { |o| o.api_json }
+    result = OrganisationType.order(:description).map(&:api_json)
     render json: result, status: :ok
   end
 end

--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -1,2 +1,8 @@
 class OrganisationType < ApplicationRecord
+  def api_json
+    {
+      ccms_code:,
+      description:,
+    }.as_json
+  end
 end

--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -1,8 +1,5 @@
 class OrganisationType < ApplicationRecord
   def api_json
-    {
-      ccms_code:,
-      description:,
-    }.as_json
+    as_json(only: %i[ccms_code description])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,17 +3,20 @@
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => "/api-docs"
   mount Rswag::Api::Engine => "/api-docs"
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
   resources :merits_tasks, param: :ccms_code, only: %i[create]
   resources :civil_merits_questions, param: :ccms_code, only: %i[create]
-  get "proceeding_types/all", to: "proceeding_types/searches#index"
+
   get "client_involvement_types", to: "client_involvement_types#index"
+  get "organisation_types/all", to: "organisation_types#index"
+  get "proceeding_types/all", to: "proceeding_types/searches#index"
+
   resources :proceeding_types, param: :ccms_code, only: %i[show]
   namespace :proceeding_types do
     resources :threshold_waivers, only: %i[create]
     resources :searches, only: %i[create]
   end
+
   resources :threshold_waivers, only: %i[create]
   resources :proceeding_type_defaults, only: %i[create]
   resources :proceeding_type_scopes, only: %i[create]

--- a/spec/factories/organisation_types.rb
+++ b/spec/factories/organisation_types.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :organisation_type do
+    ccms_code { "CHAR" }
+    description { "Charity" }
+  end
+end

--- a/spec/models/organisation_type_spec.rb
+++ b/spec/models/organisation_type_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe OrganisationType do
+  subject(:organisation_type) { create(:organisation_type) }
+
+  describe "#api_json" do
+    subject(:api_json) { organisation_type.api_json }
+
+    it "returns expected JSON response payload item" do
+      expect(api_json).to eql({ "ccms_code" => "CHAR", "description" => "Charity" })
+    end
+  end
+end

--- a/spec/requests/organisation_types_controller_swagger_spec.rb
+++ b/spec/requests/organisation_types_controller_swagger_spec.rb
@@ -1,0 +1,44 @@
+require "swagger_helper"
+
+RSpec.describe "organisation_types" do
+  path "/organisation_types/all" do
+    get("Get all organisation types") do
+      description "Returns an array of all organisation types with ccms codes."
+
+      tags "Organisation types"
+
+      produces "application/json"
+
+      response(200, "successful") do
+        expected_result = [
+          { "ccms_code" => "CHAR", "description" => "Charity" },
+          { "ccms_code" => "CO", "description" => "Court" },
+          { "ccms_code" => "GOVT", "description" => "Government Department" },
+          { "ccms_code" => "HMO", "description" => "HM Prison or Young Offender Institute" },
+          { "ccms_code" => "HOA", "description" => "Housing Association" },
+          { "ccms_code" => "IRC", "description" => "Immigration Removal Centre" },
+          { "ccms_code" => "LTD", "description" => "Limited Company" },
+          { "ccms_code" => "LLP", "description" => "Limited Liability Partnership" },
+          { "ccms_code" => "LA", "description" => "Local Authority" },
+          { "ccms_code" => "NHS", "description" => "National Health Service" },
+          { "ccms_code" => "PART", "description" => "Partnership" },
+          { "ccms_code" => "POLICE", "description" => "Police Authority" },
+          { "ccms_code" => "PLC", "description" => "Public Limited Company" },
+          { "ccms_code" => "SOLE", "description" => "Sole Trader" },
+        ]
+
+        example "application/json",
+                :success,
+                expected_result,
+                "Successful request",
+                "Returns an array of all organisation types with ccms codes."
+        run_test! do |response|
+          expect(response).to have_http_status(:ok)
+          expect(response.media_type).to eql("application/json")
+          expect(JSON.parse(response.body).count).to eq 14
+          expect(JSON.parse(response.body)).to eq expected_result
+        end
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -157,6 +157,51 @@ paths:
                   summary: Successful request
                   description: Returns an array of all client involvement types with
                     summary data.
+  "/organisation_types/all":
+    get:
+      summary: Get all organisation types
+      description: Returns an array of all organisation types with ccms codes.
+      tags:
+      - Organisation types
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              examples:
+                success:
+                  value:
+                  - ccms_code: CHAR
+                    description: Charity
+                  - ccms_code: CO
+                    description: Court
+                  - ccms_code: GOVT
+                    description: Government Department
+                  - ccms_code: HMO
+                    description: HM Prison or Young Offender Institute
+                  - ccms_code: HOA
+                    description: Housing Association
+                  - ccms_code: IRC
+                    description: Immigration Removal Centre
+                  - ccms_code: LTD
+                    description: Limited Company
+                  - ccms_code: LLP
+                    description: Limited Liability Partnership
+                  - ccms_code: LA
+                    description: Local Authority
+                  - ccms_code: NHS
+                    description: National Health Service
+                  - ccms_code: PART
+                    description: Partnership
+                  - ccms_code: POLICE
+                    description: Police Authority
+                  - ccms_code: PLC
+                    description: Public Limited Company
+                  - ccms_code: SOLE
+                    description: Sole Trader
+                  summary: Successful request
+                  description: Returns an array of all organisation types with ccms
+                    codes.
   "/proceeding_type_defaults":
     post:
       summary: Return details of default scope and level of service for specified


### PR DESCRIPTION
## What
Add new endpoint to retrieve all organisation types

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4281)

So organisation types can be retrieved for use in Apply front-end (descriptions)
and for CCMS injection (ccms_code).

## Commits
- remove reference to non-existent folder `spec/requests/swagger_docs`
- Add endpoint
- Add request spec and use to update swagger doc for endpoint

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
