### PR TITLE
Refactor api_json methods

### DIFF
--- a/app/controllers/client_involvement_types_controller.rb
+++ b/app/controllers/client_involvement_types_controller.rb
@@ -1,6 +1,6 @@
 class ClientInvolvementTypesController < ApplicationController
   def index
-    result = ClientInvolvementType.order(:ordering).map { |cit| JSON.parse(cit.api_json) }
+    result = ClientInvolvementType.order(:ordering).map(&:api_json)
     render json: result, status: :ok
   end
 end

--- a/app/controllers/proceeding_types/searches_controller.rb
+++ b/app/controllers/proceeding_types/searches_controller.rb
@@ -1,7 +1,7 @@
 module ProceedingTypes
   class SearchesController < ApplicationController
     def index
-      result = ProceedingType.all.map { |pt| JSON.parse(pt.api_json) }
+      result = ProceedingType.all.map(&:api_json)
       render json: result.to_json, status: :ok
     end
 

--- a/app/models/client_involvement_type.rb
+++ b/app/models/client_involvement_type.rb
@@ -4,9 +4,6 @@ class ClientInvolvementType < ApplicationRecord
   validates :ccms_code, inclusion: { in: VALID_CLIENT_INVOLVEMENT_TYPES, message: "%{value} is not a valid client_involvement_type" }
 
   def api_json
-    {
-      ccms_code:,
-      description:,
-    }.to_json
+    as_json(only: %i[ccms_code description])
   end
 end

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -50,10 +50,22 @@ class ProceedingType < ApplicationRecord
       meaning:,
       description:,
       full_s8_only:,
-      ccms_category_law: matter_type.category_of_law,
-      ccms_matter_code: matter_type.code,
-      ccms_matter: matter_type.name,
+      ccms_category_law:,
+      ccms_matter_code:,
+      ccms_matter:,
     }.as_json
+  end
+
+  def ccms_category_law
+    matter_type.category_of_law
+  end
+
+  def ccms_matter_code
+    matter_type.code
+  end
+
+  def ccms_matter
+    matter_type.name
   end
 
   def self.populate

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -53,7 +53,7 @@ class ProceedingType < ApplicationRecord
       ccms_category_law: matter_type.category_of_law,
       ccms_matter_code: matter_type.code,
       ccms_matter: matter_type.name,
-    }.to_json
+    }.as_json
   end
 
   def self.populate

--- a/spec/models/client_involvement_type_spec.rb
+++ b/spec/models/client_involvement_type_spec.rb
@@ -1,15 +1,17 @@
 require "rails_helper"
 
 RSpec.describe ClientInvolvementType do
+  subject(:client_involvement_type) { create(:client_involvement_type) }
+
   it { is_expected.to respond_to(:ccms_code, :description, :ordering) }
 
   it { is_expected.to validate_inclusion_of(:ccms_code).in_array(described_class::VALID_CLIENT_INVOLVEMENT_TYPES).with_message(/is not a valid client_involvement_type/) }
 
-  describe ".api_json" do
-    subject(:api_json) { create(:client_involvement_type).api_json }
+  describe "#api_json" do
+    subject(:api_json) { client_involvement_type.api_json }
 
     it "returns the expected json keys" do
-      expect(JSON.parse(api_json).keys).to match_array(%w[ccms_code description])
+      expect(api_json.keys).to match_array(%w[ccms_code description])
     end
   end
 end

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ProceedingType do
           "ccms_category_law" => proceeding_type.matter_type.category_of_law,
           "ccms_matter_code" => proceeding_type.matter_type.code,
           "ccms_matter" => proceeding_type.matter_type.name,
-        }.to_json,
+        },
       )
     end
   end

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -6,6 +6,26 @@ RSpec.describe ProceedingType do
   it { is_expected.to have_many(:proceeding_type_service_levels).dependent(:destroy) }
   it { is_expected.to have_many(:service_levels).through(:proceeding_type_service_levels) }
 
+  describe "#api_json" do
+    subject(:api_json) { proceeding_type.api_json }
+
+    let(:proceeding_type) { create(:proceeding_type) }
+
+    it "returns the expected json key value pairs" do
+      expect(api_json).to eql(
+        {
+          "ccms_code" => proceeding_type.ccms_code,
+          "meaning" => proceeding_type.meaning,
+          "description" => proceeding_type.description,
+          "full_s8_only" => proceeding_type.full_s8_only,
+          "ccms_category_law" => proceeding_type.matter_type.category_of_law,
+          "ccms_matter_code" => proceeding_type.matter_type.code,
+          "ccms_matter" => proceeding_type.matter_type.name,
+        }.to_json,
+      )
+    end
+  end
+
   describe "#service_levels" do
     subject(:service_levels) { proceeding_type.service_levels }
 


### PR DESCRIPTION

## What
Refactor all existing api_json

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

For consistency and to prevent unnecessary re-parsing of reponses as json

`JSON.parse(some_model_or_hash.to_json)` is the same
as `some_model_or_hash.as_json`. So amend #api_json
to use activesupport `as_json` and remove need to 
`JSON.parse` in the controller.

- Refactor: amend client_involvement_type#api_json method
- Refactor: Add passing spec for proceeding_type#api_json
- Refactor: amend proceeding_type api_json method
- Refactor: extract matter_type associations to methods

Additional refactors could include changing the `as_json` method
overrides in some models (e.g. app/models/scope_limitation), or 
use of serialization classes as in this [thoughtbot article](https://thoughtbot.com/blog/better-serialization-less-as-json)

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
