### PR TITLE
AP-4399: add organisation type code to payload and rename attributes

### DIFF
--- a/app/controllers/organisation_searches_controller.rb
+++ b/app/controllers/organisation_searches_controller.rb
@@ -1,6 +1,6 @@
 class OrganisationSearchesController < ApplicationController
   def index
-    result = Organisation.order(:name).all.map(&:api_json)
+    result = Organisation.includes(:organisation_type).order(:name).all.map(&:api_json)
     render json: result, status: :ok
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -4,6 +4,11 @@ class Organisation < ApplicationRecord
   validates :name, :ccms_code, :searchable_type, presence: true
 
   def api_json
-    as_json(only: %i[name ccms_code searchable_type])
+    {
+      name:,
+      ccms_opponent_id: ccms_code,
+      ccms_type_text: searchable_type,
+      ccms_type_code: organisation_type.ccms_code,
+    }.as_json
   end
 end

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -27,7 +27,12 @@ RSpec.describe Organisation do
     subject(:api_json) { organisation.api_json }
 
     it "returns expected JSON response payload item" do
-      expect(api_json).to eql({ "ccms_code" => "280361", "name" => "Angus Council", "searchable_type" => "Local Authority" })
+      expect(api_json).to eql({
+        "name" => "Angus Council",
+        "ccms_opponent_id" => "280361",
+        "ccms_type_code" => "LA",
+        "ccms_type_text" => "Local Authority",
+      })
     end
   end
 end

--- a/spec/requests/organisations_controller_swagger_spec.rb
+++ b/spec/requests/organisations_controller_swagger_spec.rb
@@ -61,8 +61,9 @@ RSpec.describe "organisations" do
                 [
                   {
                     name: "Babergh District Council",
-                    ccms_code: "280370",
-                    searchable_type: "Local Authority",
+                    ccms_opponent_id: "280370",
+                    ccms_type_code: "LA",
+                    ccms_type_text: "Local Authority",
                   },
                 ],
             }
@@ -115,18 +116,21 @@ RSpec.describe "organisations" do
                 [
                   {
                     name: "G4S",
-                    ccms_code: "381576",
-                    searchable_type: "Public Limited Company",
+                    ccms_opponent_id: "381576",
+                    ccms_type_code: "PLC",
+                    ccms_type_text: "Public Limited Company",
                   },
                   {
                     name: "Imperial College London",
-                    ccms_code: "381577",
-                    searchable_type: "Public Limited Company",
+                    ccms_opponent_id: "381577",
+                    ccms_type_code: "PLC",
+                    ccms_type_text: "Public Limited Company",
                   },
                   {
                     name: "University North Durham",
-                    ccms_code: "381578",
-                    searchable_type: "Public Limited Company",
+                    ccms_opponent_id: "381578",
+                    ccms_type_code: "PLC",
+                    ccms_type_text: "Public Limited Company",
                   },
                 ],
             }

--- a/spec/services/organisation_full_text_search_spec.rb
+++ b/spec/services/organisation_full_text_search_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe OrganisationFullTextSearch do
       end
 
       it "returns expected result" do
-        result = results.first
-        expect(result.name).to eq "Babergh District Council"
-        expect(result.searchable_type).to eq "Local Authority"
-        expect(result.ccms_code).to eq "280370"
+        expect(results.first).to have_attributes(name: "Babergh District Council",
+                                                 ccms_opponent_id: "280370",
+                                                 ccms_type_code: "LA",
+                                                 ccms_type_text: "Local Authority")
       end
     end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -260,3604 +260,4800 @@ paths:
                 success:
                   value:
                   - name: 2gether NHS Foundation Trust
-                    ccms_code: '380755'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380755'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: 5 Boroughs Partnership NHS Foundation Trust
-                    ccms_code: '380756'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380756'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Acklington
-                    ccms_code: '378922'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378922'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Aintree University Hospital NHS Trust
-                    ccms_code: '380757'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380757'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Airedale NHS Foundation Trust
-                    ccms_code: '380758'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380758'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Albany
-                    ccms_code: '378923'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378923'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Alder Hey Children's NHS Foundation Trust
-                    ccms_code: '380760'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380760'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Altcourse
-                    ccms_code: '378932'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378932'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Amber Valley Borough Council
-                    ccms_code: '280360'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280360'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Angus Council
-                    ccms_code: '280361'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280361'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Animal Health
-                    ccms_code: '378755'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378755'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Antrim Borough Council
-                    ccms_code: '280362'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280362'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ards Borough Council
-                    ccms_code: '280363'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280363'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Argyll and Bute Council
-                    ccms_code: '280364'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280364'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Armagh City and District Council
-                    ccms_code: '280365'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280365'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Arun District Council
-                    ccms_code: '280366'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280366'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ashfield District Council
-                    ccms_code: '280367'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280367'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ashford Borough Council
-                    ccms_code: '280368'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280368'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ashford and St Peter’s Hospitals NHS Foundation Trust
-                    ccms_code: '380761'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380761'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Ashton, Leigh and Wigan PCT
-                    ccms_code: '380762'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380762'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Ashwell
-                    ccms_code: '378933'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378933'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Askham Grange
-                    ccms_code: '378934'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378934'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Asset Protection Agency
-                    ccms_code: '378760'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378760'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Attorney General’s Office
-                    ccms_code: '378761'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378761'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Avon & Somerset Police
-                    ccms_code: '380786'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '380786'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Avon and Wiltshire Mental Health Partnership NHS Trust
-                    ccms_code: '380763'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380763'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Aylesbury
-                    ccms_code: '378935'
-                    searchable_type: Charity
+                    ccms_opponent_id: '378935'
+                    ccms_type_text: Charity
+                    ccms_type_code: CHAR
                   - name: Aylesbury Vale District Council
-                    ccms_code: '280369'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280369'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Babergh District Council
-                    ccms_code: '280370'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280370'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ballymena Borough Council
-                    ccms_code: '280371'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280371'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ballymoney Borough Council
-                    ccms_code: '280372'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280372'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Banbridge District Council
-                    ccms_code: '280373'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280373'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Barking Havering & Redbridge Hospitals NHS Trust
-                    ccms_code: '380775'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380775'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Barking and Dagenham PCT
-                    ccms_code: '380774'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380774'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Barnet & Chase Farm Hospitals NHS Trust
-                    ccms_code: '380788'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380788'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Barnet & Enfield PCT Holbrook House
-                    ccms_code: '380789'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380789'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Barnet PCT
-                    ccms_code: '380790'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380790'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Barnet, Enfield and Haringey Mental Health NHS Trust
-                    ccms_code: '380791'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380791'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Barnsley Hospital NHS Foundation Trust
-                    ccms_code: '380792'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380792'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Barnsley Metropolitan Borough Council
-                    ccms_code: '280374'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280374'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Barnsley PCT
-                    ccms_code: '380793'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380793'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Barrow in Furness Borough Council
-                    ccms_code: '280375'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280375'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bart & The London NHS Trust
-                    ccms_code: '380794'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380794'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Basildon Borough Council
-                    ccms_code: '280376'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280376'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Basildon and Thurrock University Hospitals NHS Trust
-                    ccms_code: '380795'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380795'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Basingstoke and Deane Borough Council
-                    ccms_code: '280377'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280377'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bassetlaw District Council
-                    ccms_code: '280378'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280378'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bassetlaw PCT
-                    ccms_code: '380796'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380796'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bath and North East Somerset Council
-                    ccms_code: '280379'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280379'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bedford Borough Council
-                    ccms_code: '280380'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280380'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bedford NHS Trust
-                    ccms_code: '380797'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380797'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bedfordshire PCT
-                    ccms_code: '380798'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380798'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bedfordshire Police HQ
-                    ccms_code: '380787'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '380787'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Belfast City Council
-                    ccms_code: '280381'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280381'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Belmarsh
-                    ccms_code: '378936'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378936'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Berkshire East PCT
-                    ccms_code: '380799'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380799'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Berkshire Healthcare NHS Foundation Trust
-                    ccms_code: '380800'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380800'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Berkshire West NHS Primary Care Trust
-                    ccms_code: '380801'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380801'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Betsi Cadwaladr University Health Board
-                    ccms_code: '380802'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380802'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bexley Care Trust
-                    ccms_code: '381463'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381463'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Birmingham Children's Hospital NHS Foundation Trust
-                    ccms_code: '380804'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380804'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Birmingham City Council
-                    ccms_code: '280382'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280382'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Birmingham Community Healthcare NHS Trust
-                    ccms_code: '380805'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380805'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Birmingham East & North PCT
-                    ccms_code: '380806'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380806'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Birmingham University Hospitals
-                    ccms_code: '380807'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380807'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Birmingham Women’s NHS Foundation Trust
-                    ccms_code: '380808'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380808'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Birmingham and Solihull Mental Health NHS Foundation Trust
-                    ccms_code: '380803'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380803'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Blaby District Council
-                    ccms_code: '280383'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280383'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Black Country Partnership NHS Foundation Trust
-                    ccms_code: '380809'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380809'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Blackburn With Darwen Teaching Care Trust Plus
-                    ccms_code: '380810'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380810'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Blackburn with Darwen Borough Council
-                    ccms_code: '280384'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280384'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Blackpool Council
-                    ccms_code: '280385'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280385'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Blackpool PCT
-                    ccms_code: '380811'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380811'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Blackpool Teaching Hospitals NHS Foundation Trust
-                    ccms_code: '380812'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380812'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Blaenau Gwent County Borough Council
-                    ccms_code: '280386'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280386'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Blakenhurst
-                    ccms_code: '378937'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378937'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Blantyre House
-                    ccms_code: '378938'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378938'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Blundeston
-                    ccms_code: '378939'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378939'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Bolsover District Council
-                    ccms_code: '280387'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280387'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bolton Metropolitan Borough Council
-                    ccms_code: '280388'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280388'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bolton NHS Foundation Trust
-                    ccms_code: '380813'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380813'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bolton PCT
-                    ccms_code: '380814'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380814'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Borough of Poole Council
-                    ccms_code: '280389'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280389'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Boston Borough Council
-                    ccms_code: '280390'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280390'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bournemouth Borough Council
-                    ccms_code: '280391'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280391'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bournemouth and Poole Teaching PCT
-                    ccms_code: '380815'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380815'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bracknell Forest Borough Council
-                    ccms_code: '280392'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280392'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bradford & Airdale Primary NHS Trust
-                    ccms_code: '380816'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380816'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bradford District Care Trust
-                    ccms_code: '380818'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380818'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bradford Teaching Hospitals NHS Foundation Trust
-                    ccms_code: '380819'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380819'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bradford and Airedale Teaching PCT
-                    ccms_code: '380817'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380817'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Braintree District Council
-                    ccms_code: '280393'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280393'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Breckland District Council
-                    ccms_code: '280394'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280394'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Brent Teaching PCT
-                    ccms_code: '380820'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380820'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Brentwood Borough Council
-                    ccms_code: '280395'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280395'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bridgend County Borough Council
-                    ccms_code: '280396'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280396'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bridgewater Community Healthcare NHS Trust
-                    ccms_code: '380821'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380821'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Brighton & Hove City Council
-                    ccms_code: '280397'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280397'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Brighton and Sussex University Hospitals NHS Trust
-                    ccms_code: '380822'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380822'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Brinsford
-                    ccms_code: '378949'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378949'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Bristol
-                    ccms_code: '378950'
-                    searchable_type: Charity
+                    ccms_opponent_id: '378950'
+                    ccms_type_text: Charity
+                    ccms_type_code: CHAR
                   - name: Bristol City Council
-                    ccms_code: '280398'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280398'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bristol PCT
-                    ccms_code: '380823'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380823'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bristol Royal Children's Hospital
-                    ccms_code: '380824'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380824'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: British National Space Agency
-                    ccms_code: '378762'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378762'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: British Transport Police London
-                    ccms_code: '381465'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381465'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Bro Morgannwg NHS Trust
-                    ccms_code: '380825'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380825'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Broadland District Council
-                    ccms_code: '280399'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280399'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Brockhill
-                    ccms_code: '378951'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378951'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Bromley Hospital NHS Trust
-                    ccms_code: '380826'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380826'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bromley PCT
-                    ccms_code: '380827'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380827'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bromsgrove District Council
-                    ccms_code: '280400'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280400'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bronzefield
-                    ccms_code: '378952'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378952'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Brook House Immigration Removal Centre
-                    ccms_code: '380744'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380744'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Broxbourne Borough Council
-                    ccms_code: '280401'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280401'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Broxbourne Housing Association
-                    ccms_code: '380735'
-                    searchable_type: Housing Association
+                    ccms_opponent_id: '380735'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
                   - name: Broxtowe Borough Council
-                    ccms_code: '283338'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283338'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Buckinghamshire County Council
-                    ccms_code: '283339'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283339'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Buckinghamshire NHS Trust
-                    ccms_code: '380828'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380828'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Buckinghamshire PCT
-                    ccms_code: '380829'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380829'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Buckley Hall
-                    ccms_code: '378953'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378953'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Bullingdon
-                    ccms_code: '378954'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378954'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Bullwood Hall
-                    ccms_code: '378955'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378955'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Burnley Borough Council
-                    ccms_code: '283340'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283340'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Burton NHS Trust
-                    ccms_code: '380830'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380830'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bury Metropolitan Borough Council
-                    ccms_code: '283341'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283341'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bury PCT
-                    ccms_code: '380831'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380831'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Buying Solutions
-                    ccms_code: '378763'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378763'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Cabinet Office
-                    ccms_code: '378764'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378764'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Caerphilly County Borough Council
-                    ccms_code: '283342'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283342'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Calderdale & Huddersfield NHS Trust
-                    ccms_code: '380832'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380832'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Calderdale Metropolitan Borough Council
-                    ccms_code: '283343'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283343'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Calderdale PCT
-                    ccms_code: '380833'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380833'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Calderstones Partnership NHS Foundation Trust
-                    ccms_code: '380834'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380834'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cambridge City Council
-                    ccms_code: '283344'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283344'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cambridge University Hospitals NHS Foundation Trust
-                    ccms_code: '380835'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380835'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cambridgeshire Community Services NHS Trust
-                    ccms_code: '380837'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380837'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cambridgeshire County Council
-                    ccms_code: '283345'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283345'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cambridgeshire PCT
-                    ccms_code: '380838'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380838'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cambridgeshire Police
-                    ccms_code: '381466'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381466'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Cambridgeshire and Peterborough NHS Foundation Trust
-                    ccms_code: '380836'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380836'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Camden PCT
-                    ccms_code: '380839'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380839'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Camp Hill
-                    ccms_code: '378956'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378956'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Campsfield House Immigration Removal Centre
-                    ccms_code: '380745'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380745'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Cannock Chase District Council
-                    ccms_code: '283346'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283346'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Canterbury City Council
-                    ccms_code: '283347'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283347'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cardiff & Vale NHS Trust
-                    ccms_code: '380840'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380840'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cardiff Council
-                    ccms_code: '283348'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283348'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Carlisle City Council
-                    ccms_code: '283349'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283349'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Carmarthenshire County Council
-                    ccms_code: '283350'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283350'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Carrickfergus Borough Council
-                    ccms_code: '282435'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282435'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Castington
-                    ccms_code: '378974'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378974'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Castle Point Borough Council
-                    ccms_code: '282436'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282436'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Castlereagh Borough Council
-                    ccms_code: '282437'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282437'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Central & Eastern Cheshire NHS PCT
-                    ccms_code: '380841'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380841'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Central Bedfordshire Council
-                    ccms_code: '282438'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282438'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Central Lancashire PCT
-                    ccms_code: '380844'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380844'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Central London Community Healthcare NHS Trust
-                    ccms_code: '380845'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380845'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Central Manchester NHS Foundation Trust
-                    ccms_code: '380846'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380846'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Central Office of Information
-                    ccms_code: '378765'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378765'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Central Scotland Police
-                    ccms_code: '381467'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381467'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Central and North West London NHS Foundation Trust
-                    ccms_code: '380843'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380843'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Centre for Environment, Fisheries and Aquaculture Science
-                    ccms_code: '378766'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378766'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Ceredigion County Council
-                    ccms_code: '282338'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282338'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Channings Wood
-                    ccms_code: '378975'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378975'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Charity Commission for England and Wales
-                    ccms_code: '378767'
-                    searchable_type: Charity
+                    ccms_opponent_id: '378767'
+                    ccms_type_text: Charity
+                    ccms_type_code: CHAR
                   - name: Charnwood Borough Council
-                    ccms_code: '282339'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282339'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Chelmsford Borough Council
-                    ccms_code: '282340'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282340'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Chelsea and Westminster Hospital NHS Foundation Trust
-                    ccms_code: '380847'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380847'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cheltenham Borough Council
-                    ccms_code: '282341'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282341'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cherwell District Council
-                    ccms_code: '282342'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282342'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cheshire East Council
-                    ccms_code: '283351'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '283351'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cheshire Police HQ
-                    ccms_code: '381468'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381468'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Cheshire West and Chester Council
-                    ccms_code: '281370'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281370'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cheshire and Wirral Partnership NHS Foundation Trust
-                    ccms_code: '380848'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380848'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Chesterfield Borough Council
-                    ccms_code: '281371'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281371'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Chesterfield NHS Foundation Trust
-                    ccms_code: '380849'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380849'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Chichester District Council
-                    ccms_code: '281372'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281372'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Child Support Agency
-                    ccms_code: '378768'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378768'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Chiltern District Council
-                    ccms_code: '281373'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281373'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Chorley Borough Council
-                    ccms_code: '281374'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281374'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Christchurch Borough Council
-                    ccms_code: '282440'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282440'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: City Hospitals Sunderland NHS Foundation Trust
-                    ccms_code: '380851'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380851'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: City and County of Swansea
-                    ccms_code: '282439'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282439'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: City and Hackney Teaching PCT
-                    ccms_code: '380850'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380850'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: City of Bradford Metropolitan District Council
-                    ccms_code: '282343'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282343'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: City of Lincoln Council
-                    ccms_code: '282344'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282344'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: City of London
-                    ccms_code: '282345'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282345'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: City of London Police HQ
-                    ccms_code: '381469'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381469'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Civil Nuclear Police Authority
-                    ccms_code: '381470'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381470'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Clackmannanshire Council
-                    ccms_code: '282346'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282346'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cleveland Police HQ
-                    ccms_code: '381471'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381471'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Colchester Borough Council
-                    ccms_code: '282347'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282347'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Colchester Hospital NHS Trust
-                    ccms_code: '380852'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380852'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Coldingley
-                    ccms_code: '378976'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378976'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Coleraine Borough Council
-                    ccms_code: '282348'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282348'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Colnbrook Immigration Removal Centre
-                    ccms_code: '380746'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380746'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Comhairle nan Eilean Siar
-                    ccms_code: '282349'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282349'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Commissioners for The Reduction of The National Debt
-                    ccms_code: '378769'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378769'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Companies House
-                    ccms_code: '378770'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378770'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Conwy County Borough Council
-                    ccms_code: '282350'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282350'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cookham Wood
-                    ccms_code: '378977'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378977'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Cookstown District Council
-                    ccms_code: '282351'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282351'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Copeland Borough Council
-                    ccms_code: '282352'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282352'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Corby Borough Council
-                    ccms_code: '282353'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282353'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cornwall Council
-                    ccms_code: '282354'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282354'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cornwall Partnership NHS Foundation Trust
-                    ccms_code: '380854'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380854'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cornwall and Isles of Scilly PCT
-                    ccms_code: '380853'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380853'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cotswold District Council
-                    ccms_code: '282355'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282355'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Council of the Isles of Scilly
-                    ccms_code: '282356'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282356'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Countess of Chester Hospital
-                    ccms_code: '380855'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380855'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: County Durham PCT
-                    ccms_code: '380856'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380856'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Coventry City Council
-                    ccms_code: '282357'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282357'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Coventry PCT
-                    ccms_code: '380859'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380859'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Coventry and Warwickshire Partnership NHS Trust
-                    ccms_code: '380858'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380858'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Craigavon Borough Council
-                    ccms_code: '282358'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282358'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Craven District Council
-                    ccms_code: '282359'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282359'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Crawley Borough Council
-                    ccms_code: '282360'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282360'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Criminal Records Bureau
-                    ccms_code: '378771'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378771'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Crown Prosecution
-                    ccms_code: '378772'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378772'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Croydon Health Service NHS Trust
-                    ccms_code: '380860'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380860'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Croydon PCT
-                    ccms_code: '380861'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380861'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cumbria County Council
-                    ccms_code: '282361'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282361'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Cumbria NHS Trust
-                    ccms_code: '380862'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380862'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cumbria Police HQ
-                    ccms_code: '381472'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381472'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Cumbria Teaching PCT
-                    ccms_code: '380863'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380863'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cwm Taf NHS Health Board
-                    ccms_code: '380864'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380864'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dacorum Borough Council
-                    ccms_code: '282362'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282362'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Darlington Borough Council
-                    ccms_code: '282363'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282363'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Darlington PCT
-                    ccms_code: '380865'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380865'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dartford Borough Council
-                    ccms_code: '282364'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282364'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Dartford and Gravesham NHS Hospital Trust
-                    ccms_code: '380866'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380866'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dartmoor
-                    ccms_code: '378978'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378978'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Daventry District Council
-                    ccms_code: '282365'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282365'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Deerbolt
-                    ccms_code: '378979'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378979'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Defence Science and Technology Laboratory
-                    ccms_code: '378773'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378773'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Defence Storage and Distribution Agency
-                    ccms_code: '378774'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378774'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Defence Support Group
-                    ccms_code: '378775'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378775'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Defence Vetting Agency
-                    ccms_code: '378776'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378776'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Department for Business Innovation and Skills
-                    ccms_code: '378777'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378777'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Department for Communities and Local Government
-                    ccms_code: '378778'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378778'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Department for Culture Olympics, Media and Sport
-                    ccms_code: '378779'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378779'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Department for Education
-                    ccms_code: '378780'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378780'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Department for Environment, Food and Rural Affairs
-                    ccms_code: '378781'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378781'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Department for International Development
-                    ccms_code: '378782'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378782'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Department for Transport London
-                    ccms_code: '378783'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378783'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Department of Energy and Climate Change
-                    ccms_code: '378784'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378784'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Department of Health
-                    ccms_code: '378785'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378785'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Derby City Council
-                    ccms_code: '282366'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282366'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Derby City PCT
-                    ccms_code: '380867'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380867'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Derby Hospitals NHS Foundation Trust
-                    ccms_code: '380868'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380868'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Derbyshire Community Health Services NHS Trust
-                    ccms_code: '380869'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380869'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Derbyshire County Council
-                    ccms_code: '282367'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282367'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Derbyshire County PCT
-                    ccms_code: '380870'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380870'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Derbyshire Dales District Council
-                    ccms_code: '282368'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282368'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Derbyshire Healthcare NHS Foundation Trust
-                    ccms_code: '380882'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380882'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Derbyshire Mental Health Trust
-                    ccms_code: '380883'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380883'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Derbyshire Police HQ
-                    ccms_code: '381473'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381473'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Derry City Council
-                    ccms_code: '281375'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281375'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Devon & Cornwall Police HQ
-                    ccms_code: '381474'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381474'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Devon County Council
-                    ccms_code: '281376'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281376'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Devon PCT
-                    ccms_code: '380885'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380885'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Devon Partnership NHS Trust
-                    ccms_code: '380884'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380884'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Diana Princess of Wales Hospital
-                    ccms_code: '380886'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380886'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Doncaster & Bassetlaw NHS Trust
-                    ccms_code: '380887'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380887'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Doncaster Council
-                    ccms_code: '281377'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281377'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Doncaster PCT
-                    ccms_code: '380888'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380888'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dorset County Council
-                    ccms_code: '281369'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281369'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Dorset County Hospital NHS Foundation Trust
-                    ccms_code: '380889'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380889'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dorset Healthcare University NHS Foundation Trust
-                    ccms_code: '380890'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380890'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dorset PCT
-                    ccms_code: '380891'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380891'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dorset Police Authority
-                    ccms_code: '381482'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381482'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Dorset Police HQ
-                    ccms_code: '381483'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381483'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Dovegate
-                    ccms_code: '378980'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378980'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Dover District Council
-                    ccms_code: '281378'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281378'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Dover Immigration Removal Centre
-                    ccms_code: '380747'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380747'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Down District Council
-                    ccms_code: '281379'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281379'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Downview
-                    ccms_code: '378981'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378981'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Driver and Vehicle Licensing Agency
-                    ccms_code: '378786'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378786'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Driving Standards Agency
-                    ccms_code: '378787'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378787'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Dudley Metropolitan Borough Council
-                    ccms_code: '281380'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281380'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Dudley PCT
-                    ccms_code: '380893'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380893'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dudley and Walsall Mental Health Partnership NHS Trust
-                    ccms_code: '380892'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380892'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dumfries & Galloway Police HQ
-                    ccms_code: '381484'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381484'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Dumfries and Galloway Council
-                    ccms_code: '281381'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281381'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Dundee City Council
-                    ccms_code: '281382'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281382'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Dungannon and South Tyrone Borough Council
-                    ccms_code: '281383'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281383'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Dungavel House Immigration Removal Centre
-                    ccms_code: '380748'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380748'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Durham & Darlington NHS Foundation Trust Darlington Memorial
                       Hospital
-                    ccms_code: '380894'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380894'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Durham Police HQ
-                    ccms_code: '381485'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381485'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Dyfed-powys Police HQ
-                    ccms_code: '381486'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381486'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Ealing NHS Trust
-                    ccms_code: '380895'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380895'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Ealing PCT
-                    ccms_code: '380896'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380896'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East & North Hertfordshire NHS Trust
-                    ccms_code: '380897'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380897'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Ayrshire Council
-                    ccms_code: '281385'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281385'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Cambridgeshire District Council
-                    ccms_code: '281386'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281386'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Cheshire NHS Trust
-                    ccms_code: '380898'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380898'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Devon District Council
-                    ccms_code: '281387'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281387'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Dorset District Council
-                    ccms_code: '281388'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281388'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Dunbartonshire Council
-                    ccms_code: '281390'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281390'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Hampshire District Council
-                    ccms_code: '281391'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281391'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Hertfordshire District Council
-                    ccms_code: '281392'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281392'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Kent University NHS Hospital
-                    ccms_code: '380899'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380899'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Lancashire Hospitals NHS Trust
-                    ccms_code: '380900'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380900'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Lancashire Teaching PCT
-                    ccms_code: '380901'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380901'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Lindsey District Council
-                    ccms_code: '281393'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281393'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East London NHS Foundation Trust
-                    ccms_code: '380902'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380902'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Lothian Council
-                    ccms_code: '281395'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281395'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Midland Ambulance Service
-                    ccms_code: '380903'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380903'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Midlands Government Office Region
-                    ccms_code: '378788'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378788'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: East Midlands Strategic Health Authority
-                    ccms_code: '380904'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380904'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Northamptonshire District Council
-                    ccms_code: '281397'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281397'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Renfrewshire Council
-                    ccms_code: '281399'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281399'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Riding of Yorkshire Council
-                    ccms_code: '281400'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281400'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Staffordshire Borough Council
-                    ccms_code: '281401'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281401'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: East Sussex Downs and Weald PCT
-                    ccms_code: '380917'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380917'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Sussex NHS Trust
-                    ccms_code: '380918'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380918'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Sutton Park
-                    ccms_code: '378982'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378982'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: East of England Ambulance Service NHS Trust
-                    ccms_code: '380907'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380907'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East of England Government Office Region
-                    ccms_code: '378793'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378793'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: East of England Strategic Health Authority
-                    ccms_code: '380908'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380908'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Eastbourne Borough Council
-                    ccms_code: '281403'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281403'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Eastern and Coastal Kent PCT
-                    ccms_code: '380919'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380919'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Eastleigh Borough Council
-                    ccms_code: '281404'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281404'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Eastwood Park
-                    ccms_code: '378983'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378983'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Eden District Council
-                    ccms_code: '281405'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281405'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Edinburgh City Council
-                    ccms_code: '281406'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281406'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Edmunds Hill
-                    ccms_code: '378984'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378984'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Elmbridge Borough Council
-                    ccms_code: '281407'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281407'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Elmley
-                    ccms_code: '378985'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378985'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Epping Forest District Council
-                    ccms_code: '281408'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281408'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Epsom & St Helier Teaching Hospitals
-                    ccms_code: '380920'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380920'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Epsom and Ewell Borough Council
-                    ccms_code: '281409'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281409'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Equality & Human Rights Commission
-                    ccms_code: '378794'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378794'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Erewash Borough Council
-                    ccms_code: '281411'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281411'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Erlestoke
-                    ccms_code: '378986'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378986'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Essex Police HQ
-                    ccms_code: '381487'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381487'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Everthorpe
-                    ccms_code: '378987'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378987'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Exeter City Council
-                    ccms_code: '281413'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281413'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: FCO Services
-                    ccms_code: '378797'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378797'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Fairfield NHS
-                    ccms_code: '380921'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380921'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Falkirk Council
-                    ccms_code: '281415'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281415'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Family Mosaic Housing Association
-                    ccms_code: '380736'
-                    searchable_type: Housing Association
+                    ccms_opponent_id: '380736'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
                   - name: Fareham Borough Council
-                    ccms_code: '281417'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281417'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Featherstone
-                    ccms_code: '378988'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378988'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Feltham
-                    ccms_code: '378989'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378989'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Fenland District Council
-                    ccms_code: '281418'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281418'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Fermanagh District Council
-                    ccms_code: '281419'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281419'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Fife Council
-                    ccms_code: '281420'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281420'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Fife Police HQ
-                    ccms_code: '381488'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381488'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Fire Service College
-                    ccms_code: '378798'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378798'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Flintshire County Council
-                    ccms_code: '281421'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281421'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Food Standards Agency
-                    ccms_code: '378809'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378809'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Ford
-                    ccms_code: '378990'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378990'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Foreign and Commonwealth Office
-                    ccms_code: '378810'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378810'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Forest Bank
-                    ccms_code: '378991'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378991'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Forest Enterprise England
-                    ccms_code: '378811'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378811'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Forest Heath District Council
-                    ccms_code: '281423'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281423'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Forest Research
-                    ccms_code: '378812'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378812'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Forest of Dean District Council
-                    ccms_code: '281424'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281424'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Forestry Commission
-                    ccms_code: '378813'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378813'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Foston Hall
-                    ccms_code: '378992'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378992'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Frankland
-                    ccms_code: '378993'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378993'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Frimley Park Hospital NHS Foundation Trust
-                    ccms_code: '380922'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380922'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Full Sutton
-                    ccms_code: '378994'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378994'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Fylde Borough Council
-                    ccms_code: '281425'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281425'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: G4S
-                    ccms_code: '381576'
-                    searchable_type: Public Limited Company
+                    ccms_opponent_id: '381576'
+                    ccms_type_text: Public Limited Company
+                    ccms_type_code: PLC
                   - name: Garth
-                    ccms_code: '378995'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378995'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Gartree
-                    ccms_code: '378996'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378996'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Gateshead Housing Company
-                    ccms_code: '380737'
-                    searchable_type: Housing Association
+                    ccms_opponent_id: '380737'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
                   - name: Gateshead Metropolitan Borough Council
-                    ccms_code: '281426'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281426'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Gateshead PCT
-                    ccms_code: '380923'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380923'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Gateshead/Sunderland Health NHS Foundation Trust
-                    ccms_code: '380924'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380924'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Gedling Borough Council
-                    ccms_code: '281427'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281427'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: George Eliot Hospital NHS Trust
-                    ccms_code: '380925'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380925'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Glasgow City Council
-                    ccms_code: '281428'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281428'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Glen Parva
-                    ccms_code: '378997'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '378997'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Gloucester City Council
-                    ccms_code: '281430'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281430'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Gloucestershire County Council
-                    ccms_code: '281431'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281431'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Gloucestershire Hospitals NHS Foundation Trust
-                    ccms_code: '380926'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380926'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Gloucestershire NHS Foundation Trust
-                    ccms_code: '380927'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380927'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Gloucestershire PCT
-                    ccms_code: '380928'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380928'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Gloucestershire Police HQ
-                    ccms_code: '381489'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381489'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Good Hope Hospital NHS Trust
-                    ccms_code: '380929'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380929'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Gosport Borough Council
-                    ccms_code: '281432'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281432'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Government Actuary’s Department
-                    ccms_code: '378814'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378814'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Government Car and Despatch Agency
-                    ccms_code: '378815'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378815'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Government Equalities Office
-                    ccms_code: '378816'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378816'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Grampian Police HQ
-                    ccms_code: '381490'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381490'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Gravesham Borough Council
-                    ccms_code: '280402'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280402'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Great Ormand Street Hospital NHS Trust
-                    ccms_code: '380930'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380930'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Great Western Ambulance Service NHS Trust
-                    ccms_code: '380931'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380931'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Great Western Hospitals NHS Foundation Trust
-                    ccms_code: '380932'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380932'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Great Yarmouth and Waveney PCT
-                    ccms_code: '380933'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380933'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Greater Manchester Police HQ
-                    ccms_code: '381491'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381491'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Greater Manchester West Mental Health NHS Foundation Trust
-                    ccms_code: '380934'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380934'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Greenwich Teaching PCT
-                    ccms_code: '380935'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380935'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Grendon
-                    ccms_code: '379016'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379016'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Guildford Borough Council
-                    ccms_code: '280403'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280403'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Guys & Thomas NHS Trust
-                    ccms_code: '380936'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380936'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Guys Marsh
-                    ccms_code: '379017'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379017'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Gwent NHS Trust
-                    ccms_code: '380937'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380937'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Gwent Police HQ
-                    ccms_code: '381492'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381492'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Gwynedd County Council
-                    ccms_code: '280404'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280404'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: HM Courts Service
-                    ccms_code: '378820'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378820'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: HM Land Registry
-                    ccms_code: '378821'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378821'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: HM Revenue and Customs
-                    ccms_code: '378822'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378822'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: HM Treasury
-                    ccms_code: '378823'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378823'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: HM Treasury Correspondence & Enquiry Unit
-                    ccms_code: '378824'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378824'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Halton & St Helens PCT Widnes Health Care Resource Centre
-                    ccms_code: '380938'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380938'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Halton Borough Council
-                    ccms_code: '280405'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280405'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hambleton District Council
-                    ccms_code: '280406'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280406'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hammersmith Hospital NHS Trust
-                    ccms_code: '380949'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380949'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hammersmith and Fulham PCT
-                    ccms_code: '380948'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380948'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hampshire Constabulary
-                    ccms_code: '381493'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381493'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Hampshire County Council
-                    ccms_code: '280407'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '280407'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hampshire Hospitals NHS Foundation Trust
-                    ccms_code: '380950'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380950'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hampshire PCT
-                    ccms_code: '380951'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380951'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hampshire Police HQ
-                    ccms_code: '381494'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381494'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Harborough District Council
-                    ccms_code: '281338'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281338'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Haringey Teaching PCT
-                    ccms_code: '380953'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380953'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Harlow District Council
-                    ccms_code: '281339'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281339'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Harmondsworth Immigration Removal Centre
-                    ccms_code: '380749'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380749'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Harrogate & District NHS Foundation Trust
-                    ccms_code: '380954'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380954'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Harrogate Borough Council
-                    ccms_code: '281340'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281340'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Harrow PCT
-                    ccms_code: '380955'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380955'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hart District Council
-                    ccms_code: '281341'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281341'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hartlepool Borough Council
-                    ccms_code: '282434'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '282434'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hartlepool PCT
-                    ccms_code: '380956'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380956'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Haslar Immigration Removal Centre
-                    ccms_code: '380750'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380750'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Hastings Borough Council
-                    ccms_code: '281342'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281342'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hastings and Rother PCT
-                    ccms_code: '380957'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380957'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Havant Borough Council
-                    ccms_code: '281345'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281345'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Haverigg
-                    ccms_code: '379018'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379018'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Havering PCT
-                    ccms_code: '380958'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380958'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Health Protection Agency
-                    ccms_code: '378817'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378817'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Health Solutions Wales
-                    ccms_code: '380959'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380959'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Heart of Birmingham Teaching PCT
-                    ccms_code: '380960'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380960'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Heart of England NHS Trust
-                    ccms_code: '380962'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380962'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Heatherwood and Wexham Park Hospitals NHS Foundation Trust
-                    ccms_code: '380963'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380963'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hereford NHS
-                    ccms_code: '380964'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380964'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Herefordshire Council
-                    ccms_code: '281346'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281346'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Herefordshire PCT
-                    ccms_code: '380965'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380965'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hertfordshire Community NHS Trust
-                    ccms_code: '380966'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380966'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hertfordshire County Council
-                    ccms_code: '281347'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281347'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hertfordshire PCT
-                    ccms_code: '380968'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380968'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hertfordshire Partnership NHS Foundation Trust
-                    ccms_code: '380967'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380967'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hertfordshire Police HQ
-                    ccms_code: '381495'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381495'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Hertsmere Borough Council
-                    ccms_code: '281348'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281348'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hewell Grange
-                    ccms_code: '379019'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379019'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Heywood, Middleton and Rochdale PCT
-                    ccms_code: '380969'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380969'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: High Down
-                    ccms_code: '379020'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379020'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: High Peak Borough Council
-                    ccms_code: '281349'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281349'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Highland Council
-                    ccms_code: '281350'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281350'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Highpoint
-                    ccms_code: '379021'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379021'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Highways Agency
-                    ccms_code: '378819'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378819'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Hillingdon PCT
-                    ccms_code: '380970'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380970'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hinchingbrooke NHS Trust
-                    ccms_code: '380971'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380971'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hinckley and Bosworth Borough Council
-                    ccms_code: '281351'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281351'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hindley
-                    ccms_code: '379022'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379022'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Hollesley Bay
-                    ccms_code: '379023'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379023'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Holme House
-                    ccms_code: '379024'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379024'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Home Office
-                    ccms_code: '378825'
-                    searchable_type: Charity
+                    ccms_opponent_id: '378825'
+                    ccms_type_text: Charity
+                    ccms_type_code: CHAR
                   - name: Homerton University Hospital NHS Foundation Trust
-                    ccms_code: '380972'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380972'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Horsham District Council
-                    ccms_code: '281352'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281352'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hounslow PCT
-                    ccms_code: '380974'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380974'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hounslow and Richmond Community Healthcare NHS Trust
-                    ccms_code: '380973'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380973'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Housing Hartlepool
-                    ccms_code: '380738'
-                    searchable_type: Housing Association
+                    ccms_opponent_id: '380738'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
                   - name: Hull Teaching PCT
-                    ccms_code: '380995'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380995'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Hull and East Yorkshire Hospitals NHS Trust
-                    ccms_code: '380994'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380994'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Humber NHS Trust
-                    ccms_code: '380996'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380996'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Humberside Police HQ
-                    ccms_code: '381496'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381496'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Huntingdonshire District Council
-                    ccms_code: '281353'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281353'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Hyndburn Borough Council
-                    ccms_code: '281354'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281354'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Identity and Passport Service
-                    ccms_code: '378826'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378826'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Imperial College Healthcare NHS Trust
-                    ccms_code: '380997'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380997'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Imperial College London
-                    ccms_code: '381577'
-                    searchable_type: Public Limited Company
+                    ccms_opponent_id: '381577'
+                    ccms_type_text: Public Limited Company
+                    ccms_type_code: PLC
                   - name: Imperial College NHS Trust
-                    ccms_code: '380998'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380998'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Independent Police Complaints Commission
-                    ccms_code: '378827'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378827'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Inverclyde Council
-                    ccms_code: '281355'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281355'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ipswich Borough Council
-                    ccms_code: '281356'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281356'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ipswich Hospital NHS Trust
-                    ccms_code: '380999'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '380999'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Isle of Anglesey County Council
-                    ccms_code: '281357'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281357'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Isle of Wight Council
-                    ccms_code: '281358'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281358'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Isle of Wight NHS Trust
-                    ccms_code: '381000'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381000'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Isle of Wight Primary Care Trust
-                    ccms_code: '381001'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381001'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Islington PCT
-                    ccms_code: '381002'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381002'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: James Paget University Hospitals NHS Foundation Trust
-                    ccms_code: '381003'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381003'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Jobcentre Plus
-                    ccms_code: '378828'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378828'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Kensington Housing Trust
-                    ccms_code: '380739'
-                    searchable_type: Housing Association
+                    ccms_opponent_id: '380739'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
                   - name: Kensington and Chelsea PCT
-                    ccms_code: '381004'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381004'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Kensington and Chelsea Tenant Management Org
-                    ccms_code: '378829'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378829'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Kent Community Health NHS Trust
-                    ccms_code: '381006'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381006'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Kent County Council
-                    ccms_code: '281359'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281359'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Kent Police HQ
-                    ccms_code: '381497'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381497'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Kent and Medway NHS and Social Care Partnership Trust
-                    ccms_code: '381005'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381005'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Kettering Borough Council
-                    ccms_code: '281360'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281360'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Kettering General Hospitals NHS Trust
-                    ccms_code: '381007'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381007'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: King's College Hospital NHS Foundation Trust
-                    ccms_code: '381009'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381009'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: King's Lynn and West Norfolk Borough Council
-                    ccms_code: '281361'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281361'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Kings College Hospital
-                    ccms_code: '381008'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381008'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Kingsmill Hospital
-                    ccms_code: '381010'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381010'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Kingston Hospital NHS Trust
-                    ccms_code: '381011'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381011'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Kingston PCT
-                    ccms_code: '381012'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381012'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Kingston upon Hull City Council
-                    ccms_code: '281362'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281362'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Kirklees Council
-                    ccms_code: '281363'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281363'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Kirklees PCT
-                    ccms_code: '381014'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381014'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Kirklevington Grange
-                    ccms_code: '379025'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379025'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Knowsley Metropolitan Borough Council
-                    ccms_code: '281364'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281364'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Knowsley PCT
-                    ccms_code: '381015'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381015'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Lambeth PCT
-                    ccms_code: '381016'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381016'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Lancashire Care NHS Foundation Trust
-                    ccms_code: '381017'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381017'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Lancashire County Council
-                    ccms_code: '281365'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281365'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Lancashire Police HQ
-                    ccms_code: '381498'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381498'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Lancashire Teaching Hospitals
-                    ccms_code: '381018'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381018'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Lancaster Castle
-                    ccms_code: '379026'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379026'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Lancaster City Council
-                    ccms_code: '281366'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281366'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Lancaster Farms
-                    ccms_code: '379027'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379027'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Larne Borough Council
-                    ccms_code: '281367'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281367'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Larne House
-                    ccms_code: '380751'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380751'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Latchmere House
-                    ccms_code: '379028'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379028'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Leeds
-                    ccms_code: '379029'
-                    searchable_type: Charity
+                    ccms_opponent_id: '379029'
+                    ccms_type_text: Charity
+                    ccms_type_code: CHAR
                   - name: Leeds City County Council
-                    ccms_code: '281368'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281368'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Leeds Community Healthcare NHS Trust
-                    ccms_code: '381021'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381021'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leeds NHS PCT
-                    ccms_code: '381022'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381022'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leeds Teaching Hospital NHS Trust
-                    ccms_code: '381023'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381023'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leeds Teaching Hospitals
-                    ccms_code: '381024'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381024'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leeds and York Partnership NHS Foundation Trust
-                    ccms_code: '381019'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381019'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leicester City PCT
-                    ccms_code: '381025'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381025'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leicester University Hospital NHS Trust
-                    ccms_code: '381026'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381026'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leicestershire Constabulary
-                    ccms_code: '381499'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381499'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Leicestershire County Council
-                    ccms_code: '281422'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281422'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Leicestershire County and Rutland PCT
-                    ccms_code: '381027'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381027'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leicestershire Partnership NHS Trust
-                    ccms_code: '381028'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381028'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leicestershire Police HQ
-                    ccms_code: '381500'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381500'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Lewes District Council
-                    ccms_code: '281416'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281416'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Lewisham NHS Trust
-                    ccms_code: '381029'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381029'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Lewisham PCT
-                    ccms_code: '381030'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381030'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leyhill
-                    ccms_code: '379030'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379030'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Lichfield District Council
-                    ccms_code: '281414'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281414'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Limavady Borough Council
-                    ccms_code: '281412'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281412'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Lincolnshire Community Health Services NHS Trust
-                    ccms_code: '381031'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381031'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Lincolnshire County Council
-                    ccms_code: '281410'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281410'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Lincolnshire Police HQ
-                    ccms_code: '381501'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381501'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Lincolnshire Teaching Hospitals Primary Care Trust
-                    ccms_code: '381032'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381032'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Lindholme
-                    ccms_code: '379031'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379031'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Lisburn City Council
-                    ccms_code: '281429'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281429'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Littlehey
-                    ccms_code: '379032'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379032'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Liverpool City Council
-                    ccms_code: '281389'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281389'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Liverpool Community Health NHS Trust
-                    ccms_code: '381033'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381033'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Liverpool Heart and Chest NHS Foundation Trust
-                    ccms_code: '381034'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381034'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Liverpool PCT NHS Trust
-                    ccms_code: '381035'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381035'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Liverpool Womens NHS Trust
-                    ccms_code: '381036'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381036'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: London Ambulance Service NHS Trust
-                    ccms_code: '381039'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381039'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: London Borough of Barking and Dagenham Council
-                    ccms_code: '281394'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281394'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Barnet Council
-                    ccms_code: '281396'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281396'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Bexley Council
-                    ccms_code: '281398'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281398'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Bromley Council
-                    ccms_code: '281384'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281384'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Camden Council
-                    ccms_code: '281433'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281433'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Croydon Council
-                    ccms_code: '281434'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281434'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Ealing Council
-                    ccms_code: '281435'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281435'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Enfield Council
-                    ccms_code: '281436'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281436'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Hackney Council
-                    ccms_code: '281437'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281437'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Hammersmith and Fulham Council
-                    ccms_code: '281438'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281438'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Haringey Council
-                    ccms_code: '281439'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281439'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Harrow Council
-                    ccms_code: '281440'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281440'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Havering Council
-                    ccms_code: '281441'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281441'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Hillingdon Council
-                    ccms_code: '281442'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281442'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Hounslow Council
-                    ccms_code: '281443'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281443'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Islington Council
-                    ccms_code: '281444'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281444'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Lambeth Council
-                    ccms_code: '281445'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281445'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Lewisham Council
-                    ccms_code: '281446'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281446'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Merton Council
-                    ccms_code: '281447'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281447'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Newham Council
-                    ccms_code: '281448'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281448'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Redbridge Council
-                    ccms_code: '281449'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281449'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Richmond upon Thames Council
-                    ccms_code: '281450'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281450'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Sutton Council
-                    ccms_code: '281456'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281456'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Tower Hamlets Council
-                    ccms_code: '281458'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281458'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Waltham Forest Council
-                    ccms_code: '281460'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281460'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Borough of Wandsworth Council
-                    ccms_code: '281462'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281462'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: London Government Office Region
-                    ccms_code: '378830'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378830'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: London Probation Trust
-                    ccms_code: '378831'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378831'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: London Strategic Health Authority
-                    ccms_code: '381040'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381040'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: London and Quadrant Housing Association
-                    ccms_code: '380740'
-                    searchable_type: Housing Association
+                    ccms_opponent_id: '380740'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
                   - name: Long Lartin
-                    ccms_code: '379033'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379033'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Lothian & Borders Police HQ
-                    ccms_code: '381502'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381502'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Low Newton
-                    ccms_code: '379034'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379034'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Lowdham Grange
-                    ccms_code: '379035'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379035'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Luton & Dunstable NHS Trust
-                    ccms_code: '381041'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381041'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Luton Borough Council
-                    ccms_code: '281464'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281464'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Luton PCT
-                    ccms_code: '381042'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381042'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: MI5 (director General of Security)
-                    ccms_code: '378836'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378836'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: MI6 (secret Intelligence Service)
-                    ccms_code: '378837'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378837'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Magherafelt District Council
-                    ccms_code: '281465'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281465'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Maidstone & Tunbridge Wells NHS Hospital
-                    ccms_code: '381053'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381053'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Maidstone Borough Council
-                    ccms_code: '281467'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281467'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Maldon District Council
-                    ccms_code: '281469'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281469'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Malvern Hills District Council
-                    ccms_code: '281470'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281470'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Manchester City Council
-                    ccms_code: '281471'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281471'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Manchester Mental Health and Social Care Trust
-                    ccms_code: '381054'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381054'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Manchester PCT
-                    ccms_code: '381089'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381089'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Mansfield District Council
-                    ccms_code: '281472'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281472'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Maritime and Coastguard Agency
-                    ccms_code: '378832'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378832'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Mayor's Office for Policing and Crime
-                    ccms_code: '381503'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381503'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Medicines and Healthcare Products and Regulatory Agency
                       (mhra)
-                    ccms_code: '378833'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378833'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Medway Council
-                    ccms_code: '281473'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281473'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Medway NHS Trust
-                    ccms_code: '381090'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381090'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Medway PCT
-                    ccms_code: '381091'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381091'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Melton Borough Council
-                    ccms_code: '281475'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281475'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Mendip District Council
-                    ccms_code: '281477'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281477'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Mental Health Tribunal for Scotland
-                    ccms_code: '378834'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378834'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Mersey Care NHS Trust
-                    ccms_code: '381092'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381092'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Merseyside Police HQ
-                    ccms_code: '381516'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381516'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Merthyr Tydfil County Borough Council
-                    ccms_code: '281479'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281479'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Met Office
-                    ccms_code: '378835'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378835'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Metropolitan Police
-                    ccms_code: '381517'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381517'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Mid Cheshire NHS Trust
-                    ccms_code: '381093'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381093'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Mid Devon District Council
-                    ccms_code: '281480'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281480'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Mid Essex Hospital Services NHS Trust
-                    ccms_code: '381094'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381094'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Mid Essex PCT
-                    ccms_code: '381095'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381095'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Mid Staffordshire NHS Foundation Trust Staffordshire General
                       Hospital
-                    ccms_code: '381096'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381096'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Mid Suffolk District Council
-                    ccms_code: '281484'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281484'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Mid Sussex District Council
-                    ccms_code: '281486'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281486'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Mid Yorkshire Hospitals NHS Trust
-                    ccms_code: '381097'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381097'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Middlesbrough Council
-                    ccms_code: '291474'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '291474'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Middlesbrough Council
-                    ccms_code: '281487'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281487'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Middlesbrough PCT
-                    ccms_code: '381098'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381098'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Midlothian Council
-                    ccms_code: '281489'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281489'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Milton Keynes Council
-                    ccms_code: '281491'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281491'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Milton Keynes NHS Foundation Hospitals Trust
-                    ccms_code: '381099'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381099'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Milton Keynes PCT
-                    ccms_code: '381100'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381100'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Ministry of Defence
-                    ccms_code: '378838'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378838'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Ministry of Defence Police and Guarding Agency
-                    ccms_code: '378839'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378839'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Ministry of Justice
-                    ccms_code: '378840'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378840'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Mole Valley District Council
-                    ccms_code: '281493'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281493'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Monmouthshire County Council
-                    ccms_code: '281495'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281495'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Moorfields Eye Hospital NHS Foundation Trust
-                    ccms_code: '381101'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381101'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Moorland Closed
-                    ccms_code: '379036'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379036'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Moorland Open
-                    ccms_code: '379037'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379037'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Moray Council
-                    ccms_code: '281496'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281496'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Morton Hall
-                    ccms_code: '379038'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379038'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Morton Hall Immigration Removal Centre
-                    ccms_code: '380752'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380752'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Moyle District Council
-                    ccms_code: '281497'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281497'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: NHS Blood 7 Transport
-                    ccms_code: '378847'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378847'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: NHS Direct NHS Trust
-                    ccms_code: '381106'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381106'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: National Archives
-                    ccms_code: '378841'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378841'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: National Assembly for Wales
-                    ccms_code: '378842'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378842'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: National Fraud Authority
-                    ccms_code: '378843'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378843'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: National Measurement Office
-                    ccms_code: '378844'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378844'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: National Policing Improvement Agency
-                    ccms_code: '381518'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381518'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: National School of Government
-                    ccms_code: '378846'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378846'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: National offender Management Service (noms)
-                    ccms_code: '378845'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378845'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Neath Port Talbot County Borough Council
-                    ccms_code: '281499'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281499'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: New Forest District Council
-                    ccms_code: '281501'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281501'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: New Hall
-                    ccms_code: '379039'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379039'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Newark and Sherwood District Council
-                    ccms_code: '281503'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281503'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Newcastle CC
-                    ccms_code: '298345'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '298345'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Newcastle City Council
-                    ccms_code: '298370'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '298370'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Newcastle PCT
-                    ccms_code: '381102'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381102'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Newcastle Upon Tyne Hospitals NHS Foundation Trust
-                    ccms_code: '381103'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381103'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Newcastle under Lyme Borough Council
-                    ccms_code: '281505'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281505'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Newcastle upon Tyne City Council
-                    ccms_code: '281507'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281507'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Newham PCT
-                    ccms_code: '381104'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381104'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Newham University NHS Trust
-                    ccms_code: '381105'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381105'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Newport City Council
-                    ccms_code: '281509'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281509'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Newry and Mourne District Council
-                    ccms_code: '281510'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281510'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Newtownabbey Borough Council
-                    ccms_code: '281512'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281512'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Norfolk & Norwich NHS Trust
-                    ccms_code: '381107'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381107'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Norfolk Community Health and Care NHS Trust
-                    ccms_code: '381109'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381109'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Norfolk County Council
-                    ccms_code: '281514'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281514'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Norfolk Police HQ
-                    ccms_code: '381527'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381527'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Norfolk Primary Care Trust
-                    ccms_code: '381110'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381110'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Norfolk and Suffolk NHS Foundation Trust
-                    ccms_code: '381108'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381108'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Ayrshire Council
-                    ccms_code: '281516'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281516'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Bristol NHS Trust
-                    ccms_code: '381111'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381111'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Cumbria NHS Trust
-                    ccms_code: '381112'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381112'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Cumbria University Hospitals NHS Trust
-                    ccms_code: '381113'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381113'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Devon Council
-                    ccms_code: '281518'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281518'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Dorset District Council
-                    ccms_code: '281519'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281519'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Down Borough Council
-                    ccms_code: '281520'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281520'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North East Ambulance Service NHS Foundation Trust
-                    ccms_code: '381114'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381114'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North East Derbyshire District Council
-                    ccms_code: '281522'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281522'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North East Essex PCT
-                    ccms_code: '381115'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381115'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North East Government Office Region
-                    ccms_code: '378848'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378848'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: North East Lincolnshire Care Trust Plus
-                    ccms_code: '381116'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381116'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North East Lincolnshire Council
-                    ccms_code: '281524'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281524'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North East London NHS Foundation Trust
-                    ccms_code: '381117'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381117'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North East Strategic Health Authority
-                    ccms_code: '381118'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381118'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North East Wales NHS Trust
-                    ccms_code: '381119'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381119'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Essex Partnership NHS Foundation Trust
-                    ccms_code: '381121'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381121'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Hertfordshire District Council
-                    ccms_code: '281526'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281526'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Kesteven District Council
-                    ccms_code: '281528'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281528'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Lanarkshire Council
-                    ccms_code: '281530'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281530'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Lancashire Teaching PCT
-                    ccms_code: '381122'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381122'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Lincolnshire Council
-                    ccms_code: '281531'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281531'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Lincolnshire NHS Trust
-                    ccms_code: '381123'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381123'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Lincolnshire PCT
-                    ccms_code: '381124'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381124'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Middlesex University Hospital NHS Trust
-                    ccms_code: '381125'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381125'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Norfolk District Council
-                    ccms_code: '281533'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281533'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Sea Camp
-                    ccms_code: '379040'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379040'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: North Somerset District Council
-                    ccms_code: '281535'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281535'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Somerset PCT
-                    ccms_code: '381126'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381126'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Staffordshire NHS Trust/university Hospitals
-                    ccms_code: '381127'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381127'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Staffordshire PCT
-                    ccms_code: '381128'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381128'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Tees & Hartlepool NHS Trust
-                    ccms_code: '381129'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381129'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Tyneside Metropolitan Borough Council
-                    ccms_code: '281537'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281537'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Tyneside PCT
-                    ccms_code: '381130'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381130'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Wales Police HQ
-                    ccms_code: '381529'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381529'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: North Warwickshire Borough Council
-                    ccms_code: '281539'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281539'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North West Ambulance Service NHS Trust
-                    ccms_code: '381131'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381131'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North West Government Office Region
-                    ccms_code: '378849'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378849'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: North West Leicestershire District Council
-                    ccms_code: '281541'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281541'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North West London Hospital NHS Trust
-                    ccms_code: '381144'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381144'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North West Strategic Health Authority
-                    ccms_code: '381145'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381145'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Yorkshire & York PCT
-                    ccms_code: '381146'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381146'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: North Yorkshire County Council
-                    ccms_code: '281543'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281543'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: North Yorkshire Police HQ
-                    ccms_code: '381534'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381534'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Northampton Borough Council
-                    ccms_code: '281545'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281545'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Northampton General Hospital NHS Trust
-                    ccms_code: '381147'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381147'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Northampton Magistrate Court
-                    ccms_code: '378750'
-                    searchable_type: Court
+                    ccms_opponent_id: '378750'
+                    ccms_type_text: Court
+                    ccms_type_code: CO
                   - name: Northampton NHS Trust
-                    ccms_code: '381148'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381148'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Northamptonshire County Council
-                    ccms_code: '281546'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281546'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Northamptonshire Healthcare NHS Foundation Trust
-                    ccms_code: '381149'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381149'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Northamptonshire Police HQ
-                    ccms_code: '381535'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381535'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Northamptonshire Teaching PCT
-                    ccms_code: '381150'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381150'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Northern Devon Healthcare NHS Trust
-                    ccms_code: '381151'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381151'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Northern Ireland Office
-                    ccms_code: '378850'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378850'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Northern Ireland Policing Board
-                    ccms_code: '381536'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381536'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Northern Lincolnshire and Goole Hospitals NHS Foundation
                       Trust
-                    ccms_code: '381152'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381152'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Northern Police HQ
-                    ccms_code: '381547'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381547'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Northumberland Care Trust
-                    ccms_code: '381153'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381153'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Northumberland County Council
-                    ccms_code: '281548'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281548'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Northumberland, Tyne and Wear NHS Foundation Trust
-                    ccms_code: '381154'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381154'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Northumbria Healthcare NHS Foundation Trust
-                    ccms_code: '381155'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381155'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Northumbria Police HQ
-                    ccms_code: '381548'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381548'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Northwick Park Hospital
-                    ccms_code: '381156'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381156'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Norwich City Council
-                    ccms_code: '281550'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281550'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Notting Hill Housing Trust
-                    ccms_code: '380742'
-                    searchable_type: Housing Association
+                    ccms_opponent_id: '380742'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
                   - name: Nottingham City Council
-                    ccms_code: '281552'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281552'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Nottingham City Hospital
-                    ccms_code: '381157'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381157'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Nottingham City PCT
-                    ccms_code: '381158'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381158'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Nottingham University Hospitals NHS Trust
-                    ccms_code: '381159'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381159'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Nottinghamshire County Council
-                    ccms_code: '281554'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281554'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Nottinghamshire County Teaching PCT
-                    ccms_code: '381160'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381160'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Nottinghamshire Healthcare Trust
-                    ccms_code: '381161'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381161'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Nottinghamshire Police HQ
-                    ccms_code: '381549'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381549'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Nuffield Orthopaedic Centre NHS Trust
-                    ccms_code: '381162'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381162'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Nugent Care Society
-                    ccms_code: '378851'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378851'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Nuneaton and Bedworth Borough Council
-                    ccms_code: '281556'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281556'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Oadby and Wigston Borough Council
-                    ccms_code: '281451'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281451'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Office for Standards In Education, Children's Services and
                       Skills
-                    ccms_code: '378852'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378852'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Office of Gas and Electricity Markets
-                    ccms_code: '378853'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378853'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Office of Qualifications and Examinations Regulation
-                    ccms_code: '378854'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378854'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Office of Rail Regulation
-                    ccms_code: '378855'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378855'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Office of The Leader of The House of Commons and Lord Privy
                       Seal
-                    ccms_code: '378856'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378856'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Office of The Public Guardian
-                    ccms_code: '378857'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378857'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Office of Water Services
-                    ccms_code: '378858'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378858'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Official Receiver (insolvency Service)
-                    ccms_code: '378859'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378859'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Official Solicitor
-                    ccms_code: '378860'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378860'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Oldham Metropolitan Borough Council
-                    ccms_code: '281452'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281452'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Oldham PCT
-                    ccms_code: '381163'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381163'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Omagh District Council
-                    ccms_code: '281453'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281453'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Onley
-                    ccms_code: '379041'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379041'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Ordnance Survey
-                    ccms_code: '378861'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378861'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Orkney Islands Council
-                    ccms_code: '281454'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281454'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Oxford & Buckinghamshire Mental Health Trust
-                    ccms_code: '381164'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381164'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Oxford City Council
-                    ccms_code: '281455'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281455'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Oxford Health NHS Foundation Trust
-                    ccms_code: '381165'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381165'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Oxford University Hospitals NHS Trust
-                    ccms_code: '381166'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381166'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Oxfordshire County Council
-                    ccms_code: '281457'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281457'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Oxfordshire Learning Disability NHS Trust
-                    ccms_code: '381170'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381170'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Oxfordshire PCT
-                    ccms_code: '381171'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381171'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Oxleas NHS Foundation Trust
-                    ccms_code: '381172'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381172'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Papworth NHS Trust
-                    ccms_code: '381173'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381173'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Parkhurst
-                    ccms_code: '379042'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379042'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Parole Board
-                    ccms_code: '378862'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378862'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Pembrokeshire County Council
-                    ccms_code: '281459'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281459'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Pendle Borough Council
-                    ccms_code: '281461'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281461'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Pennine Acute Hospitals NHS Trust
-                    ccms_code: '381178'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381178'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Pennine Care NHS Foundation Trust
-                    ccms_code: '381186'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381186'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Pennine House
-                    ccms_code: '380753'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380753'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Pension, Disability and Carers Service
-                    ccms_code: '378863'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378863'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Pentonville
-                    ccms_code: '379043'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379043'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: People, Pay and Pensions Agency
-                    ccms_code: '378864'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378864'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Perth and Kinross Council
-                    ccms_code: '281463'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281463'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Peterborough & Stamford NHS Foundation Trust
-                    ccms_code: '381187'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381187'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Peterborough City Council
-                    ccms_code: '281466'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281466'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Peterborough PCT
-                    ccms_code: '381192'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381192'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Planning Inspectorate
-                    ccms_code: '378865'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378865'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Plymouth City Council
-                    ccms_code: '281468'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281468'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Plymouth Hospitals NHS Trust
-                    ccms_code: '381193'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381193'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Plymouth Teaching PCT
-                    ccms_code: '381194'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381194'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Police Service for Northern Ireland HQ
-                    ccms_code: '381550'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381550'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Poole Hospital NHS Trust Foundation
-                    ccms_code: '381195'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381195'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Portland
-                    ccms_code: '379044'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379044'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Portsmouth City Teaching PCT
-                    ccms_code: '381196'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381196'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Portsmouth Hospitals NHS Trust
-                    ccms_code: '381197'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381197'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Postal Services Commission
-                    ccms_code: '378866'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378866'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Powys County Council
-                    ccms_code: '281474'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281474'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Prescoed
-                    ccms_code: '379045'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379045'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Preston City Council
-                    ccms_code: '281476'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281476'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Prime Minister's Office
-                    ccms_code: '378867'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378867'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Public Health Wales NHS Trust
-                    ccms_code: '381198'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381198'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Public Works Loan Board
-                    ccms_code: '378868'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378868'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Purbeck District Council
-                    ccms_code: '281478'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281478'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Queen Elizabeth Hospital NHS Trust
-                    ccms_code: '381199'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381199'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Queen Elizabeth Ii Conference Centre
-                    ccms_code: '378869'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378869'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Queen Victoria Hospital NHS Foundation Trust
-                    ccms_code: '381200'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381200'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Ranby
-                    ccms_code: '379046'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '379046'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Reading Borough Council
-                    ccms_code: '281481'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281481'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Redbridge PCT
-                    ccms_code: '381201'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381201'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Redcar and Cleveland Borough Council
-                    ccms_code: '281482'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281482'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Redcar and Cleveland Local Authority
-                    ccms_code: '296351'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '296351'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Redcar and Cleveland PCT
-                    ccms_code: '381202'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381202'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Redditch Borough Council
-                    ccms_code: '281483'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281483'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Refugee Council HQ
-                    ccms_code: '378870'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378870'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Reigate and Banstead Borough Council
-                    ccms_code: '281485'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281485'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Renfrewshire Council
-                    ccms_code: '281488'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281488'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rhondda Cynon Taf County Borough Council
-                    ccms_code: '281490'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281490'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ribble Valley Borough Council
-                    ccms_code: '281492'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281492'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Richmond and Twickenham PCT
-                    ccms_code: '381203'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381203'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Richmondshire District Council
-                    ccms_code: '281494'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281494'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Risley
-                    ccms_code: '380677'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380677'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Rochdale Metropolitan Borough Council
-                    ccms_code: '281498'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281498'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rochford District Council
-                    ccms_code: '281500'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281500'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rossendale Borough Council
-                    ccms_code: '281502'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281502'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rother District Council
-                    ccms_code: '281504'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281504'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rotherham Metropolitan Borough Council
-                    ccms_code: '281506'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281506'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rotherham PCT
-                    ccms_code: '381204'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381204'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Rotherham, Doncaster and South Humber NHS Foundation Trust
-                    ccms_code: '381205'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381205'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal Berkshire NHS Foundation Trust
-                    ccms_code: '381206'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381206'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal Bolton Hospital NHS Foundation Trust
-                    ccms_code: '381207'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381207'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal Borough of Greenwich
-                    ccms_code: '281508'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281508'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Royal Borough of Kensington and Chelsea Council
-                    ccms_code: '281511'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281511'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Royal Borough of Kingston upon Thames Council
-                    ccms_code: '281513'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281513'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Royal Brompton and Harefield NHS Foundation Trust
-                    ccms_code: '381208'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381208'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal Cornwall Hospital NHS Trust
-                    ccms_code: '381209'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381209'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal Devon & Exeter NHS Foundation Trust
-                    ccms_code: '381210'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381210'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal Free London NHS Foundation Trust
-                    ccms_code: '381211'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381211'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal Liverpool and Broadgreen NHS University Hospital
-                    ccms_code: '381212'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381212'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal National Hospital for Rheumatic Diseases NHS Foundation
                       Trust
-                    ccms_code: '381213'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381213'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal National Orthopaedic Hospital NHS Trust
-                    ccms_code: '381214'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381214'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal Surrey County Hospital NHS Foundation Trust
-                    ccms_code: '381215'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381215'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Royal United Hospital Bath NHS Trust
-                    ccms_code: '381216'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381216'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Rugby Borough Council
-                    ccms_code: '281515'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281515'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Runnymede Borough Council
-                    ccms_code: '281517'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281517'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rural Payments Agency
-                    ccms_code: '378871'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378871'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Rushcliffe Borough Council
-                    ccms_code: '281521'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281521'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rushmoor Borough Council
-                    ccms_code: '281523'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281523'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rutland County Council
-                    ccms_code: '281525'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281525'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Rye Hill
-                    ccms_code: '380678'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380678'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Ryedale District Council
-                    ccms_code: '281527'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281527'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: SOCA
-                    ccms_code: '381552'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381552'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Salford City Council
-                    ccms_code: '281529'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281529'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Salford NHS Trust
-                    ccms_code: '381217'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381217'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Salford PCT
-                    ccms_code: '381218'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381218'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Salford Royal NHS Trust
-                    ccms_code: '381219'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381219'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Salisbury NHS Foundation Trust
-                    ccms_code: '381220'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381220'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sandwell Metropolitan Borough Council
-                    ccms_code: '281532'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281532'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Sandwell PCT
-                    ccms_code: '381222'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381222'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sandwell and West Birmingham Hospitals NHS Trust
-                    ccms_code: '381221'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381221'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Scarborough & North East Yorkshire NHS Trust
-                    ccms_code: '381223'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381223'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Scarborough Borough Council
-                    ccms_code: '281534'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281534'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Scotland Office
-                    ccms_code: '378872'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378872'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Scottish Borders Council
-                    ccms_code: '281536'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281536'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Scottish Crime & Drug Enforcement Agency Police HQ
-                    ccms_code: '381551'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381551'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Secretary of State Home Department
-                    ccms_code: '378875'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378875'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Secretary of State for Defence War Office
-                    ccms_code: '378873'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378873'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Secretary of State for Transport
-                    ccms_code: '378874'
-                    searchable_type: Charity
+                    ccms_opponent_id: '378874'
+                    ccms_type_text: Charity
+                    ccms_type_code: CHAR
                   - name: Sedgemoor District Council
-                    ccms_code: '281538'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281538'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Sefton Council
-                    ccms_code: '281540'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281540'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Sefton PCT
-                    ccms_code: '381224'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381224'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Selby District Council
-                    ccms_code: '281542'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281542'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Send
-                    ccms_code: '380679'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380679'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Serious Fraud Office
-                    ccms_code: '378876'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378876'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Service Children's Education
-                    ccms_code: '378877'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378877'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Service Personnel and Veterans Agency (ex-service and Veterens
                       Personel Issues)
-                    ccms_code: '378878'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378878'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Sevenoaks District Council
-                    ccms_code: '281544'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281544'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Sheffield Children's NHS Foundation Trust
-                    ccms_code: '381226'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381226'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sheffield Children’s NHS Trust
-                    ccms_code: '381225'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381225'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sheffield City Council
-                    ccms_code: '281547'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281547'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Sheffield Health and Social Care NHS Foundation Trust
-                    ccms_code: '381231'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381231'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sheffield PCT
-                    ccms_code: '381232'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381232'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sheffield Teaching Hospitals NHS Foundation Trust
-                    ccms_code: '381233'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381233'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Shepway District Council
-                    ccms_code: '281549'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281549'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Sherwood forest Hospitals NHS Foundation Trust
-                    ccms_code: '381234'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381234'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Shetland Islands Council
-                    ccms_code: '281551'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281551'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Shrewsbury and Telford Hospital NHS Trust
-                    ccms_code: '381235'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381235'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Shropshire Community Health NHS Trust
-                    ccms_code: '381236'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381236'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Shropshire Council
-                    ccms_code: '281553'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281553'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Shropshire County PCT
-                    ccms_code: '381237'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381237'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Skills Funding Agency
-                    ccms_code: '378895'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378895'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Slough Borough Council
-                    ccms_code: '281555'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281555'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Solent NHS Trust
-                    ccms_code: '381238'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381238'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Solicitors Regulation Authority
-                    ccms_code: '378896'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378896'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Solihull Metropolitan Borough Council
-                    ccms_code: '281557'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281557'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Solihull NHS Trust
-                    ccms_code: '381239'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381239'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Solihull PCT
-                    ccms_code: '381240'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381240'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Somerset County Council
-                    ccms_code: '281558'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281558'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Somerset NHS Hospital Primary Care Trust
-                    ccms_code: '381241'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381241'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Somerset Partnership NHS Foundation Trust
-                    ccms_code: '381242'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381242'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Ayrshire Council
-                    ccms_code: '281559'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281559'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Birmingham PCT
-                    ccms_code: '381243'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381243'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Bucks District Council
-                    ccms_code: '281563'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281563'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Cambridgeshire District Council
-                    ccms_code: '281565'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281565'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Central Ambulance Service NHS Foundation Trust
-                    ccms_code: '381244'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381244'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Central Strategic Health Authority
-                    ccms_code: '381245'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381245'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Derbyshire District Council
-                    ccms_code: '281567'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281567'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Devon Healthcare NHS Foundation Trust
-                    ccms_code: '381246'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381246'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Durham NHS Trust
-                    ccms_code: '381247'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381247'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South East Coast Ambulance Service NHS Foundation Trust
-                    ccms_code: '381248'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381248'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South East Coast Strategic Health Authority
-                    ccms_code: '381249'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381249'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South East Essex PCT
-                    ccms_code: '381250'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381250'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South East Government Office Region
-                    ccms_code: '378897'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378897'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: South Essex Partnership NHS Trust
-                    ccms_code: '381251'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381251'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Gloucestershire Council
-                    ccms_code: '281573'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281573'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Gloucestershire PCT
-                    ccms_code: '381252'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381252'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Hams District Council
-                    ccms_code: '281575'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281575'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Holland District Council
-                    ccms_code: '281577'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281577'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Kesteven District Council
-                    ccms_code: '281579'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281579'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Lakeland District Council
-                    ccms_code: '281581'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281581'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Lanarkshire Council
-                    ccms_code: '281583'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281583'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South London & Maudsley NHS Trust
-                    ccms_code: '381253'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381253'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South London Healthcare NHS Trust
-                    ccms_code: '381254'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381254'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Norfolk Council
-                    ccms_code: '281586'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281586'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Northamptonshire Council
-                    ccms_code: '281588'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281588'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Oxfordshire District Council
-                    ccms_code: '281590'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281590'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Ribble Borough Council
-                    ccms_code: '281592'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281592'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Somerset District Council
-                    ccms_code: '281593'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281593'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Staffordshire Council
-                    ccms_code: '281594'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281594'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Staffordshire PCT
-                    ccms_code: '381256'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381256'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Staffordshire and Shropshire Healthcare NHS Foundation
                       Trust
-                    ccms_code: '381255'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381255'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Tees NHS Trust
-                    ccms_code: '381257'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381257'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Tyneside Metropolitan Borough Council
-                    ccms_code: '281595'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281595'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: South Tyneside NHS Foundation Trust
-                    ccms_code: '381258'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381258'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Tyneside PCT
-                    ccms_code: '381259'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381259'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Wales Police HQ
-                    ccms_code: '381553'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381553'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: South Warwickshire NHS Foundation Trust
-                    ccms_code: '381260'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381260'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South West Essex PCT
-                    ccms_code: '381261'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381261'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South West Government Office Region
-                    ccms_code: '378898'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378898'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: South West London and St George's Mental Health NHS Trust
-                    ccms_code: '381262'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381262'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South West Strategic Health Authority
-                    ccms_code: '381263'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381263'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South West Yorkshire Partnership NHS Foundation Trust
-                    ccms_code: '381264'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381264'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Western Ambulance Service NHS Foundation Trust
-                    ccms_code: '381265'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381265'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Yorkshire Police Authority
-                    ccms_code: '381554'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381554'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: South Yorkshire Police HQ
-                    ccms_code: '381555'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381555'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Southampton City PCT
-                    ccms_code: '381266'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381266'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Southampton University Teaching Hospitals
-                    ccms_code: '381267'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381267'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Southend University Hospital NHS Trust
-                    ccms_code: '381268'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381268'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Southend on Sea Borough Council
-                    ccms_code: '281596'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281596'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Southern Health NHS Foundation Trust
-                    ccms_code: '381269'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381269'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Southport and Ormskirk Hospital NHS Trust
-                    ccms_code: '381270'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381270'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Southwark NHS Primary Care Trust
-                    ccms_code: '381271'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381271'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Southwark PCT
-                    ccms_code: '381272'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381272'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Spelthorne Borough Council
-                    ccms_code: '281597'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281597'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Spring Hill
-                    ccms_code: '380689'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380689'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: St Albans District Council
-                    ccms_code: '281598'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281598'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: St Albans NHS
-                    ccms_code: '381464'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381464'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: St Bartholomews Hospital
-                    ccms_code: '381273'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381273'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: St Edmundsbury Borough Council
-                    ccms_code: '281599'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281599'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: St George’s NHS Hospital Trust
-                    ccms_code: '381274'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381274'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: St Helens Metropolitan Borough Council
-                    ccms_code: '281600'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281600'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: St Helens and Knowsley Hospitals NHS Trust
-                    ccms_code: '381275'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381275'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Stafford Borough Council
-                    ccms_code: '281601'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281601'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Staffordshire County Council
-                    ccms_code: '281602'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281602'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Staffordshire Moorlands District Council
-                    ccms_code: '281603'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281603'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Staffordshire Police HQ
-                    ccms_code: '381556'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381556'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Staffordshire and Stoke On Trent Partnership NHS Trust
-                    ccms_code: '381277'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381277'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Standford Hill
-                    ccms_code: '380690'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380690'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Stevenage Borough Council
-                    ccms_code: '281604'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281604'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Stirling Council
-                    ccms_code: '281605'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281605'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Stocken
-                    ccms_code: '380703'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380703'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Stockport Metropolitan Borough Council
-                    ccms_code: '281606'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281606'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Stockport NHS Foundation Trust
-                    ccms_code: '381278'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381278'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Stockport PCT
-                    ccms_code: '381279'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381279'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Stockton Borough Council
-                    ccms_code: '294391'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '294391'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Stockton-on-Tees Borough Council
-                    ccms_code: '281607'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281607'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Stockton-on-tees Teaching PCT
-                    ccms_code: '381280'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381280'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Stoke Heath
-                    ccms_code: '380719'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380719'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Stoke On Trent PCT
-                    ccms_code: '381282'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381282'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Stoke on Trent City Council
-                    ccms_code: '281608'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281608'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Strabane District Council
-                    ccms_code: '281609'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281609'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Stratford on Avon District Council
-                    ccms_code: '281610'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281610'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Strathclyde Police HQ
-                    ccms_code: '381557'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381557'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Stroud District Council
-                    ccms_code: '281611'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281611'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Styal
-                    ccms_code: '380720'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380720'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Suffolk Coastal District Council
-                    ccms_code: '281612'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281612'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Suffolk County Council
-                    ccms_code: '281613'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281613'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Suffolk Mental Health Partnership NHS Trust
-                    ccms_code: '381283'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381283'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Suffolk PCT
-                    ccms_code: '381284'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381284'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Suffolk Police HQ
-                    ccms_code: '381558'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381558'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Sunderland City Council
-                    ccms_code: '281614'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281614'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Sunderland Teaching PCT
-                    ccms_code: '381285'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381285'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Surrey & Sussex NHS Trust
-                    ccms_code: '381286'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381286'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Surrey County Council
-                    ccms_code: '281615'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281615'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Surrey Heath Borough Council
-                    ccms_code: '281616'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281616'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Surrey PCT
-                    ccms_code: '381288'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381288'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Surrey Police HQ
-                    ccms_code: '381559'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381559'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Surrey and Borders Partnership NHS Foundation Trust
-                    ccms_code: '381287'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381287'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sussex Community NHS Trust
-                    ccms_code: '381289'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381289'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sussex Partnership NHS Trust
-                    ccms_code: '381290'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381290'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sussex Police Authority
-                    ccms_code: '381560'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381560'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Sutton and Merton PCT
-                    ccms_code: '381291'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381291'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Swale Borough Council
-                    ccms_code: '281617'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281617'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Swaleside
-                    ccms_code: '380721'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380721'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Swansea NHS Trust
-                    ccms_code: '381292'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381292'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Swindon Borough Council
-                    ccms_code: '281620'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281620'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Swindon Primary Care Trust
-                    ccms_code: '381293'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381293'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Swinfen Hall
-                    ccms_code: '380722'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380722'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Tameside Hospital NHS Foundation Trust
-                    ccms_code: '381295'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381295'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Tameside Metropolitan Borough Council
-                    ccms_code: '281621'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281621'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Tameside and Glossop PCT
-                    ccms_code: '381294'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381294'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Tamworth Borough Council
-                    ccms_code: '281622'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281622'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Tandridge District Council
-                    ccms_code: '281623'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281623'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Taunton Deane Borough Council
-                    ccms_code: '281624'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281624'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Taunton and Somerset NHS Foundation Trust
-                    ccms_code: '381296'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381296'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Tavistock and Portman NHS Foundation Trust
-                    ccms_code: '381317'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381317'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Tayside Police HQ
-                    ccms_code: '381561'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381561'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Tees, Esk and Wear Valleys NHS Trust
-                    ccms_code: '381318'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381318'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Teignbridge District Council
-                    ccms_code: '281625'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281625'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Telford & Wrekin Council
-                    ccms_code: '281626'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281626'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Telford & Wrekin PCT
-                    ccms_code: '381319'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381319'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Tendring District Council
-                    ccms_code: '281627'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281627'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Test Valley Borough Council
-                    ccms_code: '281629'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281629'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Tewkesbury Borough Council
-                    ccms_code: '281631'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281631'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Thames Valley Police HQ
-                    ccms_code: '381570'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381570'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Thanet District Council
-                    ccms_code: '281634'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281634'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: The Christie NHS Foundation Trust
-                    ccms_code: '381320'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381320'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Clatterbridge Cancer Centre NHS Foundation Trust
-                    ccms_code: '381321'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381321'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Crown Estate
-                    ccms_code: '378899'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378899'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: The Dudley Group NHS Foundation Trust
-                    ccms_code: '381322'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381322'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Food and Environment Research Agency
-                    ccms_code: '378900'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378900'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: The Hillingdon Hospitals NHS Foundation Trust
-                    ccms_code: '381323'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381323'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The London Programme for IT (LPFIT)
-                    ccms_code: '378901'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378901'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: The Mount
-                    ccms_code: '380723'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380723'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: The North Midlands and East Programme for It (nmepfit)
-                    ccms_code: '378902'
-                    searchable_type: Charity
+                    ccms_opponent_id: '378902'
+                    ccms_type_text: Charity
+                    ccms_type_code: CHAR
                   - name: The Princess Alexandra Hospital NHS Trust
-                    ccms_code: '381324'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381324'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Queen Elizabeth Hospital, King's Lynn, NHS Foundation
                       Trust
-                    ccms_code: '381325'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381325'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Rotherham NHS Foundation Trust
-                    ccms_code: '381346'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381346'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Royal Bournemouth and Christchurch Hospitals NHS Foundation
                       Trust
-                    ccms_code: '381367'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381367'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Royal Marsden NHS Foundation Trust
-                    ccms_code: '381368'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381368'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Royal Orthopaedic Hospital NHS Foundation Trust
-                    ccms_code: '381369'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381369'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Royal Parks
-                    ccms_code: '378903'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378903'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: The Royal Wolverhampton Hospitals NHS Trust
-                    ccms_code: '381370'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381370'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Southern Programme for IT (SPFIT)
-                    ccms_code: '378904'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378904'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: The Verne
-                    ccms_code: '380724'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380724'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: The Walton Centre NHS Foundation Trust
-                    ccms_code: '381371'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381371'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: The Whittington Hospital NHS Trust
-                    ccms_code: '381372'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381372'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Thorn Cross
-                    ccms_code: '380725'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380725'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Three Rivers District Council
-                    ccms_code: '281636'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281636'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Thurrock Council
-                    ccms_code: '281638'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281638'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Tonbridge and Malling Borough Council
-                    ccms_code: '281640'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281640'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Torbay Council
-                    ccms_code: '281642'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281642'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Torbay and Southern Devon Health and Care NHS Trust
-                    ccms_code: '381373'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381373'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Torfaen County Borough Council
-                    ccms_code: '281644'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281644'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Torridge District Council
-                    ccms_code: '281646'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281646'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Tower Hamlets Council
-                    ccms_code: '380743'
-                    searchable_type: Housing Association
+                    ccms_opponent_id: '380743'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
                   - name: Tower Hamlets PCT NHS Trust
-                    ccms_code: '381374'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381374'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Trafford Healthcare NHS Trust
-                    ccms_code: '381375'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381375'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Trafford Metropolitan Borough Council
-                    ccms_code: '281649'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281649'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Trafford PCT
-                    ccms_code: '381376'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381376'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Treasury Solicitor's Department
-                    ccms_code: '378905'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378905'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Tribunals Service
-                    ccms_code: '378906'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378906'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Tunbridge Wells Borough Council
-                    ccms_code: '281651'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281651'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Uk Hydrographic Office
-                    ccms_code: '378907'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378907'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Uk Intellectual Property Office
-                    ccms_code: '378908'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378908'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Uk Statistics Authority
-                    ccms_code: '378909'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378909'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Uk Trade & Investment
-                    ccms_code: '378910'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378910'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: United Bristol Healthcare Trust
-                    ccms_code: '381377'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381377'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: United Lincolnshire Hospitals NHS Trust
-                    ccms_code: '381378'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381378'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University College London Hospitals NHS Foundation Trust
-                    ccms_code: '381380'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381380'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University College London NHS Trust Foundation
-                    ccms_code: '381381'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381381'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospital Lewisham NHS Trust
-                    ccms_code: '381382'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381382'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospital North Tees
-                    ccms_code: '381383'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381383'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospital Southampton NHS Foundation Trust
-                    ccms_code: '381386'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381386'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospital of North Staffordshire NHS Trust
-                    ccms_code: '381384'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381384'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospital of South Manchester
-                    ccms_code: '381385'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381385'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospitals Birmingham NHS Foundation Trust
-                    ccms_code: '381387'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381387'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospitals Bristol NHS Foundation Trust
-                    ccms_code: '381388'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381388'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospitals Coventry & Warwickshire NHS Trust
-                    ccms_code: '381389'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381389'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospitals of Leicester NHS Trust
-                    ccms_code: '381390'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381390'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University Hospitals of Morecambe Bay NHS Foundation Trust
-                    ccms_code: '381391'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381391'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: University North Durham
-                    ccms_code: '381578'
-                    searchable_type: Public Limited Company
+                    ccms_opponent_id: '381578'
+                    ccms_type_text: Public Limited Company
+                    ccms_type_code: PLC
                   - name: Uttlesford District Council
-                    ccms_code: '281653'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281653'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Vale of Glamorgan Council
-                    ccms_code: '281656'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281656'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Vale of White Horse District Council
-                    ccms_code: '281658'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281658'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Valuation Office
-                    ccms_code: '378911'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378911'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Vehicle Certification Agency
-                    ccms_code: '378913'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378913'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Vehicle and Operator Services Agency
-                    ccms_code: '378912'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378912'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Velindre NHS Trust
-                    ccms_code: '381392'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381392'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Veterinary Laboratories Agency
-                    ccms_code: '378914'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378914'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Veterinary Medicines Directorate
-                    ccms_code: '378915'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378915'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Wakefield Council
-                    ccms_code: '281560'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281560'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wakefield District PCT
-                    ccms_code: '381393'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381393'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wakefield NHS Trust White Rose House
-                    ccms_code: '381394'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381394'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wales Government Office Region
-                    ccms_code: '378916'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378916'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Wales Office
-                    ccms_code: '378917'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378917'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Walsall Healthcare NHS Trust
-                    ccms_code: '381395'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381395'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Walsall Metropolitan Borough Council
-                    ccms_code: '281561'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281561'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Walsall Teaching PCT
-                    ccms_code: '381396'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381396'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Waltham forest PCT
-                    ccms_code: '381407'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381407'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wandsworth PCT
-                    ccms_code: '381408'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381408'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Warrington Borough Council
-                    ccms_code: '281562'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281562'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Warrington PCT
-                    ccms_code: '381416'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381416'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Warrington and Halton Hospitals NHS Foundation Trust
-                    ccms_code: '381409'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381409'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Warwick District Council
-                    ccms_code: '281564'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281564'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Warwickshire County Council
-                    ccms_code: '281566'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281566'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Warwickshire PCT Acute Hospitals NHS Trust
-                    ccms_code: '381425'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381425'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Warwickshire Police HQ
-                    ccms_code: '381571'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381571'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Watford Borough Council
-                    ccms_code: '281568'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281568'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Waveney District Council
-                    ccms_code: '281569'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281569'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Waverley Borough Council
-                    ccms_code: '281570'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281570'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wayland
-                    ccms_code: '380727'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380727'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Wealden District Council
-                    ccms_code: '281571'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281571'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wealstun
-                    ccms_code: '380728'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380728'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Wellingborough Borough Council
-                    ccms_code: '281572'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281572'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Welsh Ambulance Services NHS Trust
-                    ccms_code: '381426'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381426'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Welwyn Hatfield Borough Council
-                    ccms_code: '281574'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281574'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Berkshire Council
-                    ccms_code: '281576'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281576'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Devon Borough Council
-                    ccms_code: '281578'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281578'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Dorset District Council
-                    ccms_code: '281580'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281580'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Dunbartonshire Council
-                    ccms_code: '281582'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281582'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Glamorgan Joint Childcare Legal Services
-                    ccms_code: '378918'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378918'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: West Hertfordshire Hospitals NHS Trust
-                    ccms_code: '381427'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381427'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Hertfordshire NHS Trust
-                    ccms_code: '381428'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381428'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Kent PCT
-                    ccms_code: '381429'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381429'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Lancashire Borough Council
-                    ccms_code: '281584'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281584'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Lindsey District Council
-                    ccms_code: '281585'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281585'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West London Mental Health Authority NHS Trust
-                    ccms_code: '381433'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381433'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Lothian Council
-                    ccms_code: '281587'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281587'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Mercia Police HQ
-                    ccms_code: '381572'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381572'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: West Middlesex University Hospital NHS Trust
-                    ccms_code: '381434'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381434'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Midlands Ambulance Service NHS Trust
-                    ccms_code: '381435'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381435'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Midlands Government Office Region
-                    ccms_code: '378919'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378919'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: West Midlands Police Authority
-                    ccms_code: '381573'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381573'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: West Midlands Strategic Health Authority
-                    ccms_code: '381437'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381437'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Midlands and East NHS Trust
-                    ccms_code: '381436'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381436'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Oxfordshire District Council
-                    ccms_code: '281589'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281589'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Somerset District Council
-                    ccms_code: '281591'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281591'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Suffolk NHS Foundation Trust
-                    ccms_code: '381438'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381438'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Sussex County Council
-                    ccms_code: '281402'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281402'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Sussex County Council
-                    ccms_code: '281628'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281628'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: West Sussex NHS Trust
-                    ccms_code: '381439'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381439'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Sussex PCT
-                    ccms_code: '381440'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381440'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Yorkshire Police HQ
-                    ccms_code: '381574'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381574'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Western Cheshire PCT
-                    ccms_code: '381441'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381441'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Western Sussex Hospitals NHS Trust
-                    ccms_code: '381442'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381442'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Westminster City Council
-                    ccms_code: '281630'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281630'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Westminster NHS Trust
-                    ccms_code: '381443'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381443'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Weston Area NHS Hospital Trust
-                    ccms_code: '381444'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381444'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Weymouth and Portland Borough Council
-                    ccms_code: '281632'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281632'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Whatton
-                    ccms_code: '380729'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380729'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Whipps Cross University Hospital NHS Trust
-                    ccms_code: '381445'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381445'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Whitemoor
-                    ccms_code: '380730'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380730'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Wigan Metropolitan Borough Council
-                    ccms_code: '281633'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281633'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wilton Park
-                    ccms_code: '378920'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378920'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Wiltshire Council
-                    ccms_code: '281635'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281635'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wiltshire PCT
-                    ccms_code: '381446'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381446'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wiltshire Police HQ
-                    ccms_code: '381575'
-                    searchable_type: Police Authority
+                    ccms_opponent_id: '381575'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Winchester City Council
-                    ccms_code: '281637'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281637'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Winchester and Eastleigh Healthcare NHS Trust
-                    ccms_code: '381447'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381447'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Windsor and Maidenhead Royal Borough Council
-                    ccms_code: '281639'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281639'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wirral Community NHS Trust
-                    ccms_code: '381448'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381448'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wirral Metropolitan Borough Council
-                    ccms_code: '281641'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281641'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wirral PCT
-                    ccms_code: '381449'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381449'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wirral Teaching Hospitals NHS Trust
-                    ccms_code: '381450'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381450'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Woking Borough Council
-                    ccms_code: '281643'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281643'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wokingham Borough Council
-                    ccms_code: '281645'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281645'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wolds
-                    ccms_code: '380731'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380731'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Wolverhampton City Council
-                    ccms_code: '281647'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281647'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wolverhampton City PCT
-                    ccms_code: '381451'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381451'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wolverhampton Royal NHS Trust
-                    ccms_code: '381452'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381452'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Woodhill
-                    ccms_code: '380732'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380732'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Worcester City Council
-                    ccms_code: '281648'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281648'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Worcestershire Acute Hospitals NHS Trust
-                    ccms_code: '381453'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381453'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Worcestershire County Council
-                    ccms_code: '281650'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281650'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Worcestershire Health and Care NHS Trust
-                    ccms_code: '381454'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381454'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Worcestershire NHS Trust
-                    ccms_code: '381455'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381455'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Worcestershire PCT
-                    ccms_code: '381456'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381456'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wormwood Scrubs
-                    ccms_code: '380733'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380733'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Worthing Borough Council
-                    ccms_code: '281652'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281652'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wrexham County Borough Council
-                    ccms_code: '281654'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281654'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wrightington, Wigan & Leigh NHS Foundation Trust
-                    ccms_code: '381457'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381457'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wychavon District Council
-                    ccms_code: '281655'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281655'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wycombe District Council
-                    ccms_code: '281657'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281657'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wye Valley NHS Trust
-                    ccms_code: '381458'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381458'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Wymott
-                    ccms_code: '380734'
-                    searchable_type: HM Prison or Young Offender Institute
+                    ccms_opponent_id: '380734'
+                    ccms_type_text: HM Prison or Young Offender Institute
+                    ccms_type_code: HMO
                   - name: Wyre Borough Council
-                    ccms_code: '281659'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281659'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Wyre Forest District Council
-                    ccms_code: '281660'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281660'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Yarl's Wood Immigration Removal Centre,
-                    ccms_code: '380754'
-                    searchable_type: Immigration Removal Centre
+                    ccms_opponent_id: '380754'
+                    ccms_type_text: Immigration Removal Centre
+                    ccms_type_code: IRC
                   - name: Yeovil District Hospital and NHS Trust
-                    ccms_code: '381459'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381459'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: York City Council
-                    ccms_code: '281661'
-                    searchable_type: Local Authority
+                    ccms_opponent_id: '281661'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: York Hospitals NHS Foundation Trust
-                    ccms_code: '381460'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381460'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Yorkshire & Humber NHS Trust
-                    ccms_code: '381461'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381461'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Yorkshire & The Humber Government Office Region
-                    ccms_code: '378921'
-                    searchable_type: Government Department
+                    ccms_opponent_id: '378921'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Yorkshire Ambulance Service NHS Trust
-                    ccms_code: '381462'
-                    searchable_type: National Health Service
+                    ccms_opponent_id: '381462'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   summary: Successful request
                   description: Returns an array of all organisations with summary
                     data
@@ -3882,8 +5078,9 @@ paths:
                     success: true
                     data:
                     - name: Babergh District Council
-                      ccms_code: '280370'
-                      searchable_type: Local Authority
+                      ccms_opponent_id: '280370'
+                      ccms_type_code: LA
+                      ccms_type_text: Local Authority
                   summary: Single success
                   description: When a user requests a single match it is returned
                 no_matches_found:
@@ -3899,14 +5096,17 @@ paths:
                     success: true
                     data:
                     - name: G4S
-                      ccms_code: '381576'
-                      searchable_type: Public Limited Company
+                      ccms_opponent_id: '381576'
+                      ccms_type_code: PLC
+                      ccms_type_text: Public Limited Company
                     - name: Imperial College London
-                      ccms_code: '381577'
-                      searchable_type: Public Limited Company
+                      ccms_opponent_id: '381577'
+                      ccms_type_code: PLC
+                      ccms_type_text: Public Limited Company
                     - name: University North Durham
-                      ccms_code: '381578'
-                      searchable_type: Public Limited Company
+                      ccms_opponent_id: '381578'
+                      ccms_type_code: PLC
+                      ccms_type_text: Public Limited Company
                   summary: Multiple results
                   description: When searching for a organisation type that matches
                     multiple organisations they are all returned


### PR DESCRIPTION
## What
Add organisation type ccms code to organisation payloads and rename attributes

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4399)

So that consumers (Civil Apply) can store the ccms type code against
the record directly for "injection".

Also renamed the attributes in the payload to more close reflect their 
content. We may want to rename the database table columns for completeness?!

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
