### PR TITLE
AP-4455: Add full text search "headlines" output to search endpoint

### DIFF
--- a/spec/requests/organisations_controller_swagger_spec.rb
+++ b/spec/requests/organisations_controller_swagger_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe "organisations" do
                     ccms_opponent_id: "280370",
                     ccms_type_code: "LA",
                     ccms_type_text: "Local Authority",
+                    name_headline: "<mark>Babergh</mark> District Council",
+                    type_headline: "Local Authority",
                   },
                 ],
             }
@@ -119,18 +121,24 @@ RSpec.describe "organisations" do
                     ccms_opponent_id: "381576",
                     ccms_type_code: "PLC",
                     ccms_type_text: "Public Limited Company",
+                    name_headline: "G4S",
+                    type_headline: "<mark>Public</mark> <mark>Limited</mark> <mark>Company</mark>",
                   },
                   {
                     name: "Imperial College London",
                     ccms_opponent_id: "381577",
                     ccms_type_code: "PLC",
                     ccms_type_text: "Public Limited Company",
+                    name_headline: "Imperial College London",
+                    type_headline: "<mark>Public</mark> <mark>Limited</mark> <mark>Company</mark>",
                   },
                   {
                     name: "University North Durham",
                     ccms_opponent_id: "381578",
                     ccms_type_code: "PLC",
                     ccms_type_text: "Public Limited Company",
+                    name_headline: "University North Durham",
+                    type_headline: "<mark>Public</mark> <mark>Limited</mark> <mark>Company</mark>",
                   },
                 ],
             }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -5081,6 +5081,8 @@ paths:
                       ccms_opponent_id: '280370'
                       ccms_type_code: LA
                       ccms_type_text: Local Authority
+                      name_headline: "<mark>Babergh</mark> District Council"
+                      type_headline: Local Authority
                   summary: Single success
                   description: When a user requests a single match it is returned
                 no_matches_found:
@@ -5099,14 +5101,20 @@ paths:
                       ccms_opponent_id: '381576'
                       ccms_type_code: PLC
                       ccms_type_text: Public Limited Company
+                      name_headline: G4S
+                      type_headline: "<mark>Public</mark> <mark>Limited</mark> <mark>Company</mark>"
                     - name: Imperial College London
                       ccms_opponent_id: '381577'
                       ccms_type_code: PLC
                       ccms_type_text: Public Limited Company
+                      name_headline: Imperial College London
+                      type_headline: "<mark>Public</mark> <mark>Limited</mark> <mark>Company</mark>"
                     - name: University North Durham
                       ccms_opponent_id: '381578'
                       ccms_type_code: PLC
                       ccms_type_text: Public Limited Company
+                      name_headline: University North Durham
+                      type_headline: "<mark>Public</mark> <mark>Limited</mark> <mark>Company</mark>"
                   summary: Multiple results
                   description: When searching for a organisation type that matches
                     multiple organisations they are all returned


### PR DESCRIPTION
## What
Add org name and type highlighted "headlines" to response

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4455)

Can be used to construct the search results with highlighting
built in. javascript/front-end changes required by consumer.

See [related PR](https://github.com/ministryofjustice/laa-apply-for-legal-aid/pull/5782) that consumes the "headlines" 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
