### PR TITLE
Delete PVCs in dependabot delete deployment script

### DIFF
--- a/bin/delete_dependabot_deployment
+++ b/bin/delete_dependabot_deployment
@@ -13,6 +13,8 @@ echo "$UAT_RELEASES"
 if [[ $UAT_RELEASES == *"$RELEASE_NAME"* ]]
 then
   helm delete $RELEASE_NAME --namespace=${K8S_NAMESPACE}
+  kubectl --namespace=${K8S_NAMESPACE} delete pvc -l app.kubernetes.io/instance=$RELEASE_NAME
+
   echo "Deleted UAT dependabot release $RELEASE_NAME"
 else
   echo "UAT dependabot release $RELEASE_NAME was not found"


### PR DESCRIPTION

## What
Delete PVCs in dependabot delete deployment script

Not deleted by helm delete so needed in script explicitly. 
PVCs eat up resource and cost in the cluster, particualry 
backups apparently. Raised and requested by CP.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
