### PR TITLE
Chore: Migrate deprecated deploy circle ci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,7 +163,7 @@ jobs:
           docker_layer_caching: true
       - *decrypt_secrets
       - *authenticate_k8s_live
-      - deploy:
+      - run:
           name: Helm deployment to UAT
           command: |
             echo "k8s authenticated"
@@ -179,7 +179,7 @@ jobs:
           docker_layer_caching: true
       - *decrypt_secrets
       - *authenticate_k8s_live
-      - deploy:
+      - run:
           name: Helm deployment to staging
           command: |
             helm upgrade legal-framework-api ./deploy/helm/. \
@@ -196,7 +196,7 @@ jobs:
           docker_layer_caching: true
       - *decrypt_secrets
       - *authenticate_k8s_live
-      - deploy:
+      - run:
           name: Helm deployment to production
           command: |
             helm upgrade legal-framework-api ./deploy/helm/. \


### PR DESCRIPTION
Migrate from 'deploy' to 'run' for deploy step on uat, staging and production

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
