### PR TITLE
Chore: Update circle rubocop invocation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
       - *save_gems_cache
       - run:
           name: Run Rubocop
-          command:  bin/rails rubocop
+          command:  bundle exec rubocop
   unit_tests:
     executor: test-executor
     steps:


### PR DESCRIPTION



## What

This has started to regularly fail and other circle rubocop calls use `bundle exec` rather than `bin/rails`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
