### PR TITLE
Use default/latest stable version of remote docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,7 @@ jobs:
     executor: cloud-platform-executor
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.11
+      - setup_remote_docker
       - *decrypt_secrets
       - build-and-push-to-ecr
   deploy_uat: &deploy_uat


### PR DESCRIPTION
## What

The build_and_push ci step was failing with the error "This job was rejected because the image is [unavailable]" due to us using a deprecated version of remote docker and a "brownout" documented here https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176. 

This pr updates circleci config to use the default/latest stable version of remote docker

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
