### PR TITLE
AP-4851: Add country search with fuzzy logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A client will create a payload with some search terms and the API will respond w
 A client will create a payload which will include an array of proceeding types, the API will respond with the threshold waivers for each given proceeding type
 
 ## Generation of API documentation
-If changes are made to files in this directory, regenerate the swagger documentation by executing `rake swag`.
+If changes are made to files in this directory, regenerate the swagger documentation by executing `rake rswag`.
 
 
 ## Running tests

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -4,9 +4,35 @@ class CountriesController < ApplicationController
     render json: result, status: :ok
   end
 
-  def show
-    response = Country.call(params[:ccms_code])
-    status = response[:success] ? 200 : 400
-    render json: response, status:
+  def create
+    render status:, json: { success: }.merge(results).to_json
+  end
+
+private
+
+  def success
+    @success ||= status.eql?(200) && results.symbolize_keys[:data].count.positive?
+  end
+
+  def status
+    @status ||= results.symbolize_keys[:error].present? ? 400 : 200
+  end
+
+  def results
+    if build_results.empty?
+      { data: [] }
+    else
+      { data: build_results }
+    end
+  rescue StandardError => e
+    { error: e.class.to_s, message: e.message }
+  end
+
+  def build_results
+    @build_results ||= CountriesFullTextSearch.call(search_param)
+  end
+
+  def search_param
+    params.require(:search_term)
   end
 end

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -3,4 +3,10 @@ class CountriesController < ApplicationController
     result = Country.order(:description).map(&:api_json)
     render json: result, status: :ok
   end
+
+  def show
+    response = Country.call(params[:ccms_code])
+    status = response[:success] ? 200 : 400
+    render json: response, status:
+  end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -7,4 +7,18 @@ class Country < ApplicationRecord
       description:,
     }.as_json
   end
+
+  def self.populate
+    CountriesPopulator.call
+    refresh_text_searchable
+  end
+
+  def self.refresh_text_searchable
+    update_query = <<~UPDATESQL.freeze
+      UPDATE countries
+      SET searchable =
+        setweight(to_tsvector(coalesce(description, '')), 'A');
+    UPDATESQL
+    connection.execute(update_query)
+  end
 end

--- a/app/services/countries_full_text_search.rb
+++ b/app/services/countries_full_text_search.rb
@@ -1,0 +1,68 @@
+# This class is responsible for searching the countries table for matching terms.
+#
+# It uses Postgresql's Full Text Search (see https://www.postgresql.org/docs/9.5/textsearch-intro.html)
+#
+# Results are currently returned and ranked by name and [plain english] country name. see the migration
+# which creates and stores the generated value.
+#
+# Partial word/term matching is achieved by adding a wildcard to the end of each term
+#
+class CountriesFullTextSearch
+  Result = Struct.new(:description, :code, :description_headline)
+
+  def self.call(search_terms)
+    new(search_terms).call
+  end
+
+  def initialize(search_terms)
+    @ts_query = ts_query_transform(search_terms)
+  end
+
+  def call
+    matching_results
+  end
+
+private
+
+  def matching_results
+    qs = query_string
+    result_set = Country.connection.exec_query(qs,
+                                               "-- COUNTRIES FULL TEXT SEARCH ---",
+                                               [@ts_query],
+                                               prepare: true)
+    result_set.map { |row| instantiate_result(row) }
+  end
+
+  def instantiate_result(row)
+    Result.new(row["description"].strip, row["code"], row["description_headline"])
+  end
+
+  def ts_query_transform(search_terms)
+    # transform the query into a form suitable for postgres to_tsquery function that matches
+    # on partial words
+    #
+    # "An owl & a pussycat went to sea" => "An:* & owl:* & a:* & pussycat:* & went:* & to:* & sea:*"
+    #
+    words = search_terms.split(/\s+/).map { |w| "#{w}:*" }
+    words.join(" & ").gsub("& & &", "&")
+  end
+
+  def query_string
+    <<~SQL.squish
+      SELECT
+        countries.code,
+        countries.description,
+        ts_rank(searchable, query) AS rank,
+        ts_headline(
+          'simple',
+          countries.description,
+          query,
+          'HighlightAll=true, StartSel=<mark>, StopSel=</mark>'
+        ) as description_headline
+      FROM countries,
+           to_tsquery('simple', $1) AS query
+      WHERE query @@ searchable
+      ORDER BY rank DESC;
+    SQL
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   get "organisation_types/all", to: "organisation_types#index"
   get "proceeding_types/all", to: "proceeding_types/searches#index"
   get "countries/all", to: "countries#index"
+  post "countries/search", to: "countries#create"
 
   resources :proceeding_types, param: :ccms_code, only: %i[show]
   namespace :proceeding_types do

--- a/db/migrate/20240314132923_add_searchable_to_country.rb
+++ b/db/migrate/20240314132923_add_searchable_to_country.rb
@@ -1,0 +1,12 @@
+class AddSearchableToCountry < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    add_column :countries, :searchable, :tsvector
+    add_index :countries, :searchable, using: :gin, algorithm: :concurrently
+  end
+
+  def down
+    remove_column :countries, :searchable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_15_115400) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_14_132923) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -28,6 +28,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_15_115400) do
     t.string "description", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.tsvector "searchable"
+    t.index ["searchable"], name: "index_countries_on_searchable", using: :gin
   end
 
   create_table "default_cost_limitations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,4 +26,4 @@ ClientInvolvementTypesPopulator.call
 ThresholdWaiverPopulator.call
 OrganisationTypesPopulator.call
 OrganisationsPopulator.call
-CountriesPopulator.call
+Country.populate

--- a/spec/requests/countries_controller_swagger_spec.rb
+++ b/spec/requests/countries_controller_swagger_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "countries" do
       description "Returns an array of all countries with summary data."
 
       tags "Countries"
-
       produces "application/json"
 
       response(200, "successful") do
@@ -28,6 +27,139 @@ RSpec.describe "countries" do
           expect(response).to have_http_status(:ok)
           expect(response.media_type).to eql("application/json")
           expect(JSON.parse(response.body).count).to eq 246
+        end
+      end
+    end
+  end
+
+  path "/countries/search" do
+    post("Search countries matching one or more, partial or complete, search terms/words") do
+      description "<code>POST</code> a JSON payload containing search terms to
+                  receive a response containing an array of country names and codes."
+      let(:filters) { { search_term: } }
+      let(:search_term) { "antarc" }
+
+      tags "Countries"
+      consumes "application/json"
+      produces "application/json"
+      parameter name: :filters, in: :body, schema: {
+        type: :object,
+        properties: {
+          search_term: { type: :string,
+                         example: "ant",
+                         description: "search term" },
+        },
+        required: %w[search_term],
+      }
+
+      response(200, "success") do
+        context "when the search is successful" do
+          expected_response =
+            {
+              success: true,
+              data:
+                [
+                  {
+                    description: "Antarctica",
+                    code: "ATA",
+                    description_headline: "<mark>Antarctica</mark>",
+                  },
+                ],
+            }
+
+          example "application/json",
+                  :success,
+                  expected_response,
+                  "Single success",
+                  "When a user requests a single match it is returned"
+          run_test! do |response|
+            expect(response).to have_http_status(:ok)
+            expect(response.media_type).to eql("application/json")
+            expect(parsed_response).to eq expected_response
+          end
+        end
+
+        context "when no matches found" do
+          let(:search_term) { "nonexistant" }
+
+          expected_response =
+            {
+              success: false,
+              data: [],
+            }
+
+          example "application/json",
+                  :no_matches_found,
+                  expected_response,
+                  "When no matching country exists",
+                  <<~EXPLAIN
+                    If a user requests data for a search term that does not exist the system has not
+                    errored so returns a successful status (200) but an empty array and a success false
+                  EXPLAIN
+          run_test! do |response|
+            expect(response).to have_http_status(:ok)
+            expect(response.media_type).to eql("application/json")
+            expect(parsed_response).to eq expected_response
+          end
+        end
+
+        context "when multiple matches are found" do
+          let(:filters) do
+            { search_term: "co isl" }
+          end
+
+          expected_response =
+            {
+              success: true,
+              data:
+                [
+                  {
+                    description: "Cook Islands",
+                    code: "COK",
+                    description_headline: "<mark>Cook</mark> <mark>Islands</mark>",
+                  },
+                  {
+                    description: "Cocos (Keeling) Islands",
+                    code: "CCK",
+                    description_headline: "<mark>Cocos</mark> (Keeling) <mark>Islands</mark>",
+                  },
+                ],
+            }
+
+          example "application/json",
+                  :multiple_results,
+                  expected_response,
+                  "Multiple results",
+                  "When searching for country that matches multiple countries they are all returned"
+          run_test! do |response|
+            expect(response).to have_http_status(:ok)
+            expect(response.media_type).to eql("application/json")
+            expect(parsed_response).to eq expected_response
+          end
+        end
+      end
+
+      response(400, "bad request") do
+        before do
+          allow(CountriesFullTextSearch).to receive(:call).and_raise(StandardError.new("Unexpected error in full text search"))
+        end
+
+        expected_response =
+          {
+            success: false,
+            error: "StandardError",
+            message: "Unexpected error in full text search",
+          }
+        example "application/json",
+                :search_failed,
+                expected_response,
+                "Unexpected Error",
+                "When an error occurs in the full text search"
+
+        run_test! do |response|
+          expect(response).to have_http_status(:bad_request)
+          expect(response.media_type).to eql("application/json")
+          expect(parsed_response).to match_json_expression(expected_response)
         end
       end
     end

--- a/spec/services/countries_full_text_search_spec.rb
+++ b/spec/services/countries_full_text_search_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+require_relative "full_text_search_query_transformer_examples"
+
+RSpec.describe CountriesFullTextSearch do
+  it_behaves_like "full text search query transformer"
+
+  describe ".call" do
+    subject(:results) { described_class.call(search_term) }
+
+    context "when searching for a non-existent country" do
+      let(:search_term) { "foobar" }
+
+      it "returns an empty array" do
+        expect(results).to eq []
+      end
+    end
+
+    context "when searching for an existing country" do
+      let(:search_term) { "ja" }
+
+      it "returns all expected results" do
+        expect(results.size).to eq 4
+      end
+    end
+
+    context "when searching for a term that only exists on one record" do
+      let(:search_term) { "China" }
+
+      it "returns one result row" do
+        expect(results.size).to eq 1
+      end
+
+      it "returns an instance of Result" do
+        expect(results).to all(be_an_instance_of(CountriesFullTextSearch::Result))
+      end
+
+      it "returns expected result" do
+        expect(results.first).to have_attributes(description: "China",
+                                                 code: "CHN")
+      end
+    end
+
+    context "when searching for a term which occurs in more than one country" do
+      let(:search_term) { "ant" }
+
+      it "returns expected results" do
+        expect(results.size).to eq 3
+      end
+    end
+
+    context "with multiple partial matching term searches" do
+      let(:search_term) { "sai an" }
+
+      it "returns results matching either term" do
+        expect(results.map(&:description)).to contain_exactly("Saint Kitts and Nevis",
+                                                              "Saint Pierre and Miquelon",
+                                                              "Saint Vincent and the Grenadines")
+      end
+    end
+
+    context "with multiple exact matching term searches" do
+      let(:search_term) { "saint and" }
+
+      it "returns results matching either term" do
+        expect(results.map(&:description)).to contain_exactly("Saint Kitts and Nevis",
+                                                              "Saint Pierre and Miquelon",
+                                                              "Saint Vincent and the Grenadines")
+      end
+    end
+  end
+end

--- a/spec/services/countries_full_text_search_spec.rb
+++ b/spec/services/countries_full_text_search_spec.rb
@@ -49,22 +49,19 @@ RSpec.describe CountriesFullTextSearch do
     end
 
     context "with multiple partial matching term searches" do
-      let(:search_term) { "sai an" }
+      let(:search_term) { "isl co" }
 
       it "returns results matching either term" do
-        expect(results.map(&:description)).to contain_exactly("Saint Kitts and Nevis",
-                                                              "Saint Pierre and Miquelon",
-                                                              "Saint Vincent and the Grenadines")
+        expect(results.map(&:description)).to contain_exactly("Cook Islands",
+                                                              "Cocos (Keeling) Islands")
       end
     end
 
     context "with multiple exact matching term searches" do
-      let(:search_term) { "saint and" }
+      let(:search_term) { "island cook" }
 
       it "returns results matching either term" do
-        expect(results.map(&:description)).to contain_exactly("Saint Kitts and Nevis",
-                                                              "Saint Pierre and Miquelon",
-                                                              "Saint Vincent and the Grenadines")
+        expect(results.map(&:description)).to contain_exactly("Cook Islands")
       end
     end
   end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -667,6 +667,82 @@ paths:
                     description: Zimbabwe
                   summary: Successful request
                   description: Returns an array of all countries with summary data
+  "/countries/search":
+    post:
+      summary: Search countries matching one or more, partial or complete, search
+        terms/words
+      description: |-
+        <code>POST</code> a JSON payload containing search terms to
+                          receive a response containing an array of country names and codes.
+      tags:
+      - Countries
+      parameters: []
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              examples:
+                success:
+                  value:
+                    success: true
+                    data:
+                    - description: Antarctica
+                      code: ATA
+                      description_headline: "<mark>Antarctica</mark>"
+                  summary: Single success
+                  description: When a user requests a single match it is returned
+                no_matches_found:
+                  value:
+                    success: false
+                    data: []
+                  summary: When no matching country exists
+                  description: |
+                    If a user requests data for a search term that does not exist the system has not
+                    errored so returns a successful status (200) but an empty array and a success false
+                multiple_results:
+                  value:
+                    success: true
+                    data:
+                    - description: Saint Kitts and Nevis
+                      code: KNA
+                      description_headline: "<mark>Saint</mark> Kitts <mark>and</mark>
+                        Nevis"
+                    - description: Saint Pierre and Miquelon
+                      code: SPM
+                      description_headline: "<mark>Saint</mark> Pierre <mark>and</mark>
+                        Miquelon"
+                    - description: Saint Vincent and the Grenadines
+                      code: VCT
+                      description_headline: "<mark>Saint</mark> Vincent <mark>and</mark>
+                        the Grenadines"
+                  summary: Multiple results
+                  description: When searching for country that matches multiple countries
+                    they are all returned
+        '400':
+          description: bad request
+          content:
+            application/json:
+              examples:
+                search_failed:
+                  value:
+                    success: false
+                    error: StandardError
+                    message: Unexpected error in full text search
+                  summary: Unexpected Error
+                  description: When an error occurs in the full text search
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                search_term:
+                  type: string
+                  example: ant
+                  description: search term
+              required:
+              - search_term
   "/organisation_types/all":
     get:
       summary: Get all organisation types


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4851)

Add a new, countries/search, endpoint with fuzzy logic for matching country names

Update after initial commit:

This now extracts the generation of the searchable (tsvector) text from the migration to the Country model (the same as the ProceedingType, rather than organisation)
This will allow us to re-generate the searchable text if we update the values in the seed file.  The original version would only generate it when the migration ran and would never get updated afterwards 

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
