### PR TITLE
Chore: Update CircleCI orbs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@4.1.3
-  slack: circleci/slack@4.5.2
+  slack: circleci/slack@4.13.2
 
 executors:
   basic-executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@4.0.0
+  aws-cli: circleci/aws-cli@4.1.3
   slack: circleci/slack@4.5.2
 
 executors:


### PR DESCRIPTION
## What

- Bump CircleCI aws-cli from 4.0.0 to 4.1.3
- Bump CircleCI slack from 4.5.2 to 4.13.2

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
