### PR TITLE
Chore: Update circle flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,12 +325,13 @@ workflows:
               ]
             }
           requires:
+            - deploy_main_uat
             - deploy_staging
       - hold_production:
           type: approval
           requires:
+            - deploy_main_uat
             - deploy_staging
-            - slack/on-hold
       - deploy_production:
           context: legal-framework-api-production
           requires:


### PR DESCRIPTION

## What

This aims to update the flow to be similar for all services.

If both deploys succeed, it sends the message to slack and allows the hold to be released. This means that when deploying in a hurry, emergency fixes, etc; and you are waiting to deploy you are not blocked waiting for the the slack message to be sent.

It also means that if slack is offline for any reason it does not block deploys

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
