### PR TITLE
AP-5235: SCA proceeding search

### DIFF
--- a/app/controllers/proceeding_types/filter_controller.rb
+++ b/app/controllers/proceeding_types/filter_controller.rb
@@ -1,0 +1,33 @@
+module ProceedingTypes
+  class FilterController < ApplicationController
+    def index
+      results = ProceedingTypeFilter.call(proceeding_param, category_param, search_term_param)
+      result = if results.empty?
+                 { success: false, data: [] }
+               else
+                 results
+               end
+      render json: result.to_json, status: :ok
+    end
+
+  private
+
+    def proceeding_param
+      params.require(:current_proceedings)
+    rescue ActionController::ParameterMissing
+      []
+    end
+
+    def category_param
+      params.require(:allowed_categories)
+    rescue ActionController::ParameterMissing
+      []
+    end
+
+    def search_term_param
+      params.require(:search_term)
+    rescue ActionController::ParameterMissing
+      ""
+    end
+  end
+end

--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -53,6 +53,7 @@ class ProceedingType < ApplicationRecord
       sca_core:,
       sca_related:,
       ccms_category_law:,
+      ccms_category_law_code:,
       ccms_matter_code:,
       ccms_matter:,
     }.as_json
@@ -60,6 +61,10 @@ class ProceedingType < ApplicationRecord
 
   def ccms_category_law
     matter_type.category_of_law
+  end
+
+  def ccms_category_law_code
+    matter_type.category_of_law_code
   end
 
   def ccms_matter_code

--- a/app/services/proceeding_type_filter.rb
+++ b/app/services/proceeding_type_filter.rb
@@ -1,0 +1,47 @@
+class ProceedingTypeFilter
+  def initialize(current_proceedings = [], allowed_categories = [], search_term = "")
+    @current_proceedings = current_proceedings
+    @allowed_categories = allowed_categories
+    @search_term = search_term
+    @results = @search_term.present? ? ProceedingTypeFullTextSearch.call(search_term) : ProceedingType.all.map(&:api_json)
+  end
+
+  def self.call(current_proceedings = [], allowed_categories = [], search_term = "")
+    new(current_proceedings, allowed_categories, search_term).call
+  end
+
+  def call
+    configure_sca_proceedings!
+    reject_current_proceedings!
+    reject_categories! unless @allowed_categories.empty?
+    @results
+  end
+
+private
+
+  def reject_current_proceedings!
+    @results.delete_if { |result| result["ccms_code"].in?(@current_proceedings) }
+  end
+
+  def configure_sca_proceedings!
+    @results.delete_if do |result|
+      if @current_proceedings.empty? # if current_proceedings is empty, only show SCA core
+        result["sca_related"] && result["ccms_matter_code"].eql?("KPBLW")
+      elsif current_proceedings_have_sca # if already has an SCA proceeding, exclude all non-SCA proceedings
+        result["sca_related"].eql?(false) && result["sca_core"].eql?(false)
+      else
+        result["sca_related"] || result["sca_core"]
+      end
+    end
+  end
+
+  def reject_categories!
+    @results.delete_if { |result| !result["ccms_category_law_code"].in?(@allowed_categories) }
+  end
+
+  def current_proceedings_have_sca
+    @current_proceedings_have_sca ||= ProceedingType.where(ccms_code: @current_proceedings).any? do |proceeding|
+      proceeding["sca_core"] || proceeding["sca_related"]
+    end
+  end
+end

--- a/app/services/proceeding_type_full_text_search.rb
+++ b/app/services/proceeding_type_full_text_search.rb
@@ -8,7 +8,7 @@
 # method.
 #
 class ProceedingTypeFullTextSearch
-  Result = Struct.new(:meaning, :ccms_code, :description, :full_s8_only, :sca_core, :sca_related, :ccms_category_law, :ccms_matter)
+  Result = Struct.new(:meaning, :ccms_code, :description, :full_s8_only, :sca_core, :sca_related, :ccms_category_law, :ccms_category_law_code, :ccms_matter)
 
   def self.call(search_terms, excluded_codes = [])
     new(search_terms, excluded_codes).call
@@ -45,7 +45,8 @@ private
                row["full_s8_only"],
                row["sca_core"],
                row["sca_related"],
-               row["ccms_category_law"]&.strip,
+               row["ccms_category_law"].strip,
+               row["ccms_category_law_code"]&.strip,
                row["ccms_matter"])
   end
 
@@ -69,6 +70,7 @@ private
         sca_core,
         sca_related,
         mt.category_of_law as ccms_category_law,
+        mt.category_of_law_code as ccms_category_law_code,
         mt.name as ccms_matter,
         ts_rank(textsearchable, query) AS rank
       FROM proceeding_types pt LEFT OUTER JOIN matter_types mt ON pt.matter_type_id = mt.id, to_tsquery($1) AS query

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   get "proceeding_types/all", to: "proceeding_types/searches#index"
   get "countries/all", to: "countries#index"
   post "countries/search", to: "countries#create"
+  post "proceeding_types/filter", to: "proceeding_types/filter#index"
 
   resources :proceeding_types, param: :ccms_code, only: %i[show]
   namespace :proceeding_types do

--- a/spec/models/proceeding_type_spec.rb
+++ b/spec/models/proceeding_type_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ProceedingType do
           "sca_core" => proceeding_type.sca_core,
           "sca_related" => proceeding_type.sca_related,
           "ccms_category_law" => proceeding_type.matter_type.category_of_law,
+          "ccms_category_law_code" => proceeding_type.matter_type.category_of_law_code,
           "ccms_matter_code" => proceeding_type.matter_type.code,
           "ccms_matter" => proceeding_type.matter_type.name,
         },

--- a/spec/requests/proceeding_types/filter_controller_swagger_spec.rb
+++ b/spec/requests/proceeding_types/filter_controller_swagger_spec.rb
@@ -1,0 +1,96 @@
+require "swagger_helper"
+
+RSpec.describe "proceeding_types/filter_controller" do
+  path "/proceeding_types/filter" do
+    post("Get available proceeding types dependant on current proceedings, contractual data and search terms") do
+      description "Returns an array of proceeding types with summary data.
+                   Call <code>/proceeding_types/XX999</code> where <code>XX999</code> is the ccms_code for more
+                   detailed data on a specific proceeding type."
+
+      let(:parameters) do
+        {
+          current_proceedings:,
+          allowed_categories:,
+          search_term:,
+        }
+      end
+      let(:current_proceedings) { [] }
+      let(:allowed_categories) { [] }
+      let(:search_term) { "" }
+
+      tags "Proceeding types"
+      consumes "application/json"
+      produces "application/json"
+      parameter name: :parameters, in: :body, schema: {
+        type: :object,
+        properties: {
+          current_proceedings: { type: :array,
+                                 example: %w[DA001 DA007 SE013],
+                                 description: "comma separated array of ccms codes to exclude from search results and provide filter options" },
+          allowed_categories: { type: :array,
+                                example: %w[MAT],
+                                description: "comma separated array of category of law codes that the current user is contractually entitled to" },
+          search_term: { type: :string,
+                         example: "Occupation",
+                         description: "search term that should be included in the proceeding description" },
+        },
+      }
+
+      response(200, "success") do
+        context "when the search is successful" do
+          example "application/json",
+                  :success,
+                  {
+                    success: true,
+                    data:
+                      [
+                        {
+                          meaning: "Occupation order",
+                          ccms_code: "DA005",
+                          description: "to be represented on an application for an occupation order.",
+                          full_s8_only: false,
+                          sca_core: false,
+                          sca_related: false,
+                          ccms_category_law: "Family",
+                          ccms_matter: "Domestic abuse",
+                        },
+                        {
+                          continued: "...",
+                        },
+                      ],
+                  },
+                  "Single success",
+                  "When a user requests a single match it is returned"
+          run_test! do |response|
+            expect(response).to have_http_status(:ok)
+            expect(response.media_type).to eql("application/json")
+          end
+        end
+
+        context "when the category is not yet supported in LFA" do
+          let(:allowed_categories) { %w[MED] }
+
+          expected_response =
+            {
+              success: false,
+              data: [],
+            }
+
+          example "application/json",
+                  :no_matches_found,
+                  expected_response,
+                  "When only result excluded",
+                  <<~EXPLAIN
+                    If a user requests a category that is not yet supported the system has not
+                    errored so returns a successful status (200) but an empty array and a success false
+                  EXPLAIN
+          run_test! do |response|
+            expect(response).to have_http_status(:ok)
+            expect(response.media_type).to eql("application/json")
+            expect(parsed_response).to eq expected_response
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/proceeding_types/searches_controller_swagger_spec.rb
+++ b/spec/requests/proceeding_types/searches_controller_swagger_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe "proceeding_types/searches_controller" do
                     sca_core: false,
                     sca_related: false,
                     ccms_category_law: "Family",
+                    ccms_category_law_code: "MAT",
                     ccms_matter: "Domestic abuse",
                   },
                 ],
@@ -136,6 +137,7 @@ RSpec.describe "proceeding_types/searches_controller" do
                     sca_core: false,
                     sca_related: false,
                     ccms_category_law: "Family",
+                    ccms_category_law_code: "MAT",
                     ccms_matter: "Domestic abuse",
                   },
                   {
@@ -146,6 +148,7 @@ RSpec.describe "proceeding_types/searches_controller" do
                     sca_core: false,
                     sca_related: false,
                     ccms_category_law: "Family",
+                    ccms_category_law_code: "MAT",
                     ccms_matter: "Domestic abuse",
                   },
                   {
@@ -156,6 +159,7 @@ RSpec.describe "proceeding_types/searches_controller" do
                     sca_core: false,
                     sca_related: false,
                     ccms_category_law: "Family",
+                    ccms_category_law_code: "MAT",
                     ccms_matter: "Domestic abuse",
                   },
                 ],

--- a/spec/services/proceeding_type_filter_spec.rb
+++ b/spec/services/proceeding_type_filter_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe ProceedingTypeFilter do
+  subject(:proceeding_type_filter) { described_class.call(current_proceedings, allowed_categories, search_term) }
+
+  let(:current_proceedings) { [] }
+  let(:allowed_categories) { [] }
+  let(:search_term) { "" }
+
+  context "when created with blank parameters" do
+    it "returns all proceedings excluding sca_related" do
+      expect(proceeding_type_filter.count).to eq 48
+    end
+  end
+
+  context "when created with current_proceedings parameter" do
+    context "and it has a non-SCA proceeding" do
+      let(:current_proceedings) { %w[DA001] }
+
+      it "returns all proceedings minus the current one and sca_related proceedings" do
+        expect(proceeding_type_filter.count).to eq 40
+      end
+    end
+
+    context "and it has an SCA proceeding" do
+      let(:current_proceedings) { %w[PB003] }
+
+      it "returns only sca_core and sca_related proceedings minus the current one" do
+        expect(proceeding_type_filter.count).to eq 20
+      end
+    end
+  end
+
+  context "when created with allowed_categories parameter" do
+    context "and it currently exists and has proceedings" do
+      let(:allowed_categories) { %w[MAT] }
+
+      it "returns all proceedings excluding sca_related" do
+        expect(proceeding_type_filter.count).to eq 48
+      end
+    end
+
+    context "and it is not currently supported by the service" do
+      let(:allowed_categories) { %w[MED] }
+
+      it "returns no proceedings" do
+        expect(proceeding_type_filter.count).to eq 0
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -5979,6 +5979,72 @@ paths:
               - delegated_functions_used
               - client_involvement_type
               - service_level
+  "/proceeding_types/filter":
+    post:
+      summary: Get available proceeding types dependant on current proceedings, contractual
+        data and search terms
+      description: |-
+        Returns an array of proceeding types with summary data.
+                           Call <code>/proceeding_types/XX999</code> where <code>XX999</code> is the ccms_code for more
+                           detailed data on a specific proceeding type.
+      tags:
+      - Proceeding types
+      parameters: []
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              examples:
+                success:
+                  value:
+                    success: true
+                    data:
+                    - meaning: Occupation order
+                      ccms_code: DA005
+                      description: to be represented on an application for an occupation
+                        order.
+                      full_s8_only: false
+                      sca_core: false
+                      sca_related: false
+                      ccms_category_law: Family
+                      ccms_matter: Domestic abuse
+                    - continued: "..."
+                  summary: Single success
+                  description: When a user requests a single match it is returned
+                no_matches_found:
+                  value:
+                    success: false
+                    data: []
+                  summary: When only result excluded
+                  description: |
+                    If a user requests a category that is not yet supported the system has not
+                    errored so returns a successful status (200) but an empty array and a success false
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                current_proceedings:
+                  type: array
+                  example:
+                  - DA001
+                  - DA007
+                  - SE013
+                  description: comma separated array of ccms codes to exclude from
+                    search results and provide filter options
+                allowed_categories:
+                  type: array
+                  example:
+                  - MAT
+                  description: comma separated array of category of law codes that
+                    the current user is contractually entitled to
+                search_term:
+                  type: string
+                  example: Occupation
+                  description: search term that should be included in the proceeding
+                    description
   "/proceeding_types/all":
     get:
       summary: Get summary of all proceeding types
@@ -6726,6 +6792,7 @@ paths:
                       sca_core: false
                       sca_related: false
                       ccms_category_law: Family
+                      ccms_category_law_code: MAT
                       ccms_matter: Domestic abuse
                   summary: Single success
                   description: When a user requests a single match it is returned
@@ -6750,6 +6817,7 @@ paths:
                       sca_core: false
                       sca_related: false
                       ccms_category_law: Family
+                      ccms_category_law_code: MAT
                       ccms_matter: Domestic abuse
                     - meaning: Harassment - injunction
                       ccms_code: DA003
@@ -6759,6 +6827,7 @@ paths:
                       sca_core: false
                       sca_related: false
                       ccms_category_law: Family
+                      ccms_category_law_code: MAT
                       ccms_matter: Domestic abuse
                     - meaning: Non-molestation order
                       ccms_code: DA004
@@ -6768,6 +6837,7 @@ paths:
                       sca_core: false
                       sca_related: false
                       ccms_category_law: Family
+                      ccms_category_law_code: MAT
                       ccms_matter: Domestic abuse
                   summary: Multiple results
                   description: When searching for a description that matches multiple

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -163,16 +163,15 @@ paths:
     get:
       summary: Show client involvement type for specific proceeding type
       parameters:
-        - name: proceeding_type_ccms_code
-          in: path
-          example: DA001
-          description: Proceeding_type_ccms_code, e.g. DA001
-          required: true
-          schema:
-            type: string
-      description: 
-        Returns an array of client involvement types with summary data for the specified
-        proceeding type.
+      - name: proceeding_type_ccms_code
+        in: path
+        example: DA001
+        description: Proceeding_type_ccms_code, e.g. DA001
+        required: true
+        schema:
+          type: string
+      description: Returns an array of client involvement types with summary data
+        for the specified proceeding type.
       tags:
       - Client involvement types
       responses:
@@ -196,8 +195,8 @@ paths:
                     - ccms_code: Z
                       description: Joined party
                   summary: Successful request
-                  description: Returns an array of all client involvement types with
-                    summary data.
+                  description: Returns an array of client involvement types with summary
+                    data for the specified proceeding type.
   "/countries/all":
     get:
       summary: Get all countries
@@ -6006,6 +6005,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: MINJN
                     ccms_matter: Domestic abuse
                   - ccms_code: DA002
@@ -6019,6 +6019,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: MINJN
                     ccms_matter: Domestic abuse
                   - ccms_code: DA003
@@ -6029,6 +6030,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: MINJN
                     ccms_matter: Domestic abuse
                   - ccms_code: DA004
@@ -6039,6 +6041,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: MINJN
                     ccms_matter: Domestic abuse
                   - ccms_code: DA005
@@ -6049,6 +6052,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: MINJN
                     ccms_matter: Domestic abuse
                   - ccms_code: DA006
@@ -6059,6 +6063,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: MINJN
                     ccms_matter: Domestic abuse
                   - ccms_code: DA007
@@ -6069,6 +6074,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: MINJN
                     ccms_matter: Domestic abuse
                   - ccms_code: DA020
@@ -6080,6 +6086,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: MINJN
                     ccms_matter: Domestic abuse
                   - ccms_code: SE003
@@ -6090,6 +6097,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE003A
@@ -6100,6 +6108,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE003E
@@ -6110,6 +6119,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE004
@@ -6120,6 +6130,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE004A
@@ -6130,6 +6141,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE004E
@@ -6140,6 +6152,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE007
@@ -6150,6 +6163,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE007A
@@ -6160,6 +6174,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE007E
@@ -6170,6 +6185,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE008
@@ -6180,6 +6196,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE008A
@@ -6190,6 +6207,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE008E
@@ -6200,6 +6218,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE013
@@ -6210,6 +6229,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE013A
@@ -6220,6 +6240,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE013E
@@ -6230,6 +6251,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE014
@@ -6240,6 +6262,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE014A
@@ -6250,6 +6273,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE014E
@@ -6260,6 +6284,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE015
@@ -6270,6 +6295,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE015A
@@ -6281,6 +6307,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE015E
@@ -6292,6 +6319,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE016
@@ -6302,6 +6330,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE016A
@@ -6313,6 +6342,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE016E
@@ -6324,6 +6354,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE095
@@ -6334,6 +6365,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE095A
@@ -6344,6 +6376,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE096E
@@ -6355,6 +6388,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE097
@@ -6366,6 +6400,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE097A
@@ -6377,6 +6412,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE099E
@@ -6389,6 +6425,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE100E
@@ -6401,6 +6438,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE101A
@@ -6412,6 +6450,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: SE101E
@@ -6423,6 +6462,7 @@ paths:
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KSEC8
                     ccms_matter: Children - section 8
                   - ccms_code: PB003
@@ -6433,6 +6473,7 @@ paths:
                     sca_core: true
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB004
@@ -6443,6 +6484,7 @@ paths:
                     sca_core: true
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB005
@@ -6453,6 +6495,7 @@ paths:
                     sca_core: true
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB006
@@ -6463,6 +6506,7 @@ paths:
                     sca_core: true
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB026
@@ -6473,6 +6517,7 @@ paths:
                     sca_core: true
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB057
@@ -6482,6 +6527,7 @@ paths:
                     sca_core: true
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB059
@@ -6492,6 +6538,7 @@ paths:
                     sca_core: true
                     sca_related: false
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB007
@@ -6502,6 +6549,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB012
@@ -6512,6 +6560,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB014
@@ -6522,6 +6571,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB019
@@ -6532,6 +6582,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB020
@@ -6542,6 +6593,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB021
@@ -6552,6 +6604,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB022
@@ -6562,6 +6615,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB023
@@ -6572,6 +6626,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB024
@@ -6582,6 +6637,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB027
@@ -6592,6 +6648,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB029
@@ -6602,6 +6659,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB030
@@ -6612,6 +6670,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB051
@@ -6622,6 +6681,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   - ccms_code: PB052
@@ -6632,6 +6692,7 @@ paths:
                     sca_core: false
                     sca_related: true
                     ccms_category_law: Family
+                    ccms_category_law_code: MAT
                     ccms_matter_code: KPBLW
                     ccms_matter: Special Children Act
                   summary: Successful request


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5235)

This adds a new ProceedingType endpoint, `filter` that accepts three optional parameters, `current_proceedings`, `allowed_categories`, and `search_term`

This allows us to remove proceeding types that do not comply with the rules set by the SCA requirements, e.g. 
* only show SCA core proceedings to start
* if user has already picked a non-SCA proceeding, show no SCA proceedings
* if a user has picked an SCA core proceeding, only show SCA core and related

It also includes options for categories and search text to allow us to extend the apply use to limit the categories of law that an individual provider is contractually supposed to see and restrict answers to proceedings with certain text

This _may_ allow us to remove some similar end points once we have bedded this in

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
