### PR TITLE
Chore: Enum updates

### DIFF
--- a/app/models/default_cost_limitation.rb
+++ b/app/models/default_cost_limitation.rb
@@ -1,7 +1,7 @@
 class DefaultCostLimitation < ApplicationRecord
   belongs_to :proceeding_type
 
-  enum cost_type: {
+  enum :cost_type, {
     delegated_functions: "delegated_functions".freeze,
     substantive: "substantive".freeze,
   }


### PR DESCRIPTION
## What

Changes to Rails mean that enums should use a new pattern 

In 7.2 they started adding deprecation warnings, in 8+ they will stop working.  

This PR updates to the new pattern and should reduce issues with future Rails updates

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
