### PR TITLE
Remove UAT database name from secrets

### DIFF
--- a/deploy/helm/templates/_envs.tpl
+++ b/deploy/helm/templates/_envs.tpl
@@ -18,10 +18,7 @@ env:
   - name: POSTGRES_HOST
     value: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
   - name: POSTGRES_DATABASE
-    valueFrom:
-      secretKeyRef:
-        name: {{ template "app.fullname" . }}
-        key: postgresqlDatabase
+    value: {{ .Values.postgresql.auth.database | quote }}
   {{ else }}
   - name: POSTGRES_USER
     valueFrom:

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -5,6 +5,3 @@ metadata:
 type: Opaque
 data:
   deployHost: {{ .Values.deploy.host | b64enc | quote }}
-  {{if .Values.postgresql.enabled }}
-  postgresqlDatabase: {{ .Values.postgresql.auth.database | b64enc | quote }}
-  {{end}}


### PR DESCRIPTION
## What
Remove UAT database name from secrets

[Came out of similar on hmrc interface api work](https://dsdmoj.atlassian.net/browse/AP-5157)

This value is not a secret and is already exposed in the values-uat file
in any event. This is inline with hmrc interface'es handling

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
