### PR TITLE
AP-5157: Remove deployHost secret

### DIFF
--- a/deploy/helm/templates/_envs.tpl
+++ b/deploy/helm/templates/_envs.tpl
@@ -56,8 +56,5 @@ env:
   - name: RAILS_LOG_TO_STDOUT
     value: 'true'
   - name: HOST
-    valueFrom:
-      secretKeyRef:
-        name: {{ template "app.fullname" . }}
-        key: deployHost
+    value: {{ .Values.deploy.host | quote }}
 {{- end }}

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "app.fullname" . }}
-type: Opaque
-data:
-  deployHost: {{ .Values.deploy.host | b64enc | quote }}


### PR DESCRIPTION
## What
Remove deployHost from old k8s secret

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

This is just an ingress that is visible in the Values
files and cloud-platform-environments in any event.

This removes the last secret and therefore means we no longer
need the old k8s secret at all.

It brings LFA in line with HMRC interface as well.


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
