### PR TITLE
Chore: Limit dependabot for Rails 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
       day: tuesday
       time: "03:00"
       timezone: Europe/London
+    ignore:
+      - dependency-name: rails
+        versions:
+          - ">= 8.0.0"
+      - dependency-name: action*
+        versions:
+          - ">= 8.0.0"
+      - dependency-name: active*
+        versions:
+          - ">= 8.0.0"
     groups:
       bundler:
         patterns:


### PR DESCRIPTION
## What

Rails 8 is a significant update, we will probably want to test the upgrade and investigate which of the features we want to use Therefore this PR should block dependabot from attempting to upgrade the Rails, or the individual Action* or Active*, gems.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
