### PR TITLE
Fix: add tests to achieve 100% line coverage

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -18,8 +18,9 @@ unless ENV["NOCOVERAGE"]
     add_group "Services", "app/services/"
     add_group "Validators", "app/validators/"
 
-    minimum_coverage 100
     enable_coverage :branch
+    primary_coverage :line
+    minimum_coverage branch: 90, line: 100
     refuse_coverage_drop :line, :branch
 
     at_exit do

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ An API for checking the required information for legal aid applications
 
 The API is documented at /api-docs.
 
-The documentation is generated with swagger for ruby [RSWAG](https://github.com/rswag/rswag#readme) from specs
-in the `spec/requests` folder and allows real requests to be made.
+The documentation is generated with swagger for ruby [RSWAG](https://github.com/rswag/rswag#readme) from specs in the `spec/requests` folder and allows real requests to be made.
 
 If changes are made to files in this directory, regenerate the swagger documentation by executing `NOCOVERAGE=true rake rswag`.
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -217,6 +217,17 @@ paths:
                   summary: Successful request
                   description: Returns an array of client involvement types with summary
                     data for the specified proceeding type.
+        '400':
+          description: bad request
+          content:
+            application/json:
+              examples:
+                bad_request:
+                  value:
+                    success: false
+                    message: 'No such client involvement type: ''foobar'''
+                  summary: Bad request
+                  description: Returns success false and error message
   "/countries/all":
     get:
       summary: Get all countries


### PR DESCRIPTION
## What
Add tests for client involvment type controller

[Link to story](https://dsdmoj.atlassian.net/browse/AP-XXX)

To achieve 100% line coverage. There is still below 100% branch coverage.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
