### PR TITLE
AP-4410: Add test for PLF filtering

### DIFF
--- a/spec/services/proceeding_type_filter_spec.rb
+++ b/spec/services/proceeding_type_filter_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe ProceedingTypeFilter do
         expect(proceeding_type_filter.count).to eq 20
       end
     end
+
+    context "and it has a PLF proceeding" do
+      let(:current_proceedings) { %w[PBM04] }
+
+      it "returns only PLF proceedings minus the current one" do
+        expect(proceeding_type_filter.pluck("ccms_matter_code").uniq).to eq %w[KPBLB]
+        expect(proceeding_type_filter.count).to eq 94
+      end
+    end
   end
 
   context "when created with allowed_categories parameter" do


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-4410)

Filter PLF proceedings - once a user has selected a PLF proceeding, all other matter types should be removed from the filtered return data set

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
