### PR TITLE
Fix: Fix build step issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.description="API for checking the required information for legal aid applications" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/legal-framework-api"
 
-ENV RAILS_ENV production
+ENV RAILS_ENV=production
 
 RUN set -ex
 
@@ -47,7 +47,7 @@ ENV BUILD_DATE=${BUILD_DATE}
 ENV BUILD_TAG=${BUILD_TAG}
 ENV APP_BRANCH=${APP_BRANCH}
 # allow public files to be served
-ENV RAILS_SERVE_STATIC_FILES true
+ENV RAILS_SERVE_STATIC_FILES=true
 
 USER 1001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex
 
 RUN apk --no-cache add --virtual build-dependencies \
                     build-base \
+                    yaml-dev \
                     postgresql-dev \
 && apk --no-cache add postgresql-client
 


### PR DESCRIPTION
## What

When deploying a new dependabot, the build step failed because psych could not find the yaml files needed to compile.  This PR adds yaml-dev as a temporary package so that psych can compile and then removes it with the other build dependencies

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
