### PR TITLE
AP-5603: Remove unused proceeding SE099E

### DIFF
--- a/app/models/proceeding_type.rb
+++ b/app/models/proceeding_type.rb
@@ -16,10 +16,8 @@ class ProceedingType < ApplicationRecord
            class_name: "ProceedingTask"
 
   has_many :default_cost_limitations, dependent: :destroy
-  has_many :proceeding_type_scope_limitations, dependent: :destroy
-  has_many :eligible_scope_limitations, through: :proceeding_type_scope_limitations, source: :scope_limitation
-
   has_many :proceeding_type_service_levels, dependent: :destroy
+
   has_many :service_levels, -> { select("service_levels.*, proceeding_type_service_levels.proceeding_default as proceeding_default") },
            through: :proceeding_type_service_levels,
            source: :service_level

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,6 +9,8 @@ Rails.application.configure do
   # While tests run files are not watched, reloading is not necessary.
   config.enable_reloading = false
 
+  config.cache_classes = false
+
   # Eager loading loads your entire application. When running a single test locally,
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager

--- a/lib/tasks/fixes/ap_5603.rake
+++ b/lib/tasks/fixes/ap_5603.rake
@@ -1,0 +1,39 @@
+namespace :fixes do
+  desc "Remove an proceeding type"
+  task :remove_proceeding_type, [:ccms_code] => :environment do |_task, args|
+    proceeding_type = ProceedingType.find_by(ccms_code: args[:ccms_code])
+    puts "----------------------------------------------------------"
+
+    if proceeding_type
+      puts "Found ProceedingType #{proceeding_type.ccms_code}!"
+      puts "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+      puts "This will delete:"
+      puts ""
+      puts "proceeding_type - ccms_code: #{proceeding_type.ccms_code}, meaning: #{proceeding_type.meaning} "
+      puts "#{proceeding_type.proceeding_type_merits_tasks.count} proceeding_type_merits_tasks"
+      puts "#{proceeding_type.default_cost_limitations.count} default_cost_limitations"
+      puts "#{proceeding_type.proceeding_type_service_levels.count} proceeding_type_service_levels"
+      puts ""
+
+      print "Do you want to continue (yes|no)? "
+      input = $stdin.gets.chomp
+
+      if input.downcase == "yes"
+        proceeding_type.destroy!
+
+        puts "Deleted proceeding_type #{proceeding_type.ccms_code} with meaning \"#{proceeding_type.meaning}\""
+        puts "-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+      else
+        puts "Cancelled!"
+      end
+    else
+      puts "ProceedingType #{args[:ccms_code]} not found!"
+    end
+    puts "----------------------------------------------------------"
+  end
+
+  desc "AP-55603: remove unused proceeding type SE099E"
+  task remove_proceeding_type_SE099E: :environment do
+    Rake::Task["fixes:remove_proceeding_type"].execute(ccms_code: "SE099E")
+  end
+end

--- a/spec/lib/tasks/fixes_spec.rb
+++ b/spec/lib/tasks/fixes_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe "fixes", type: :task do
+  describe ":remove_proceeding_type" do
+    subject(:run) do
+      Rake::Task["fixes:remove_proceeding_type"].execute(arguments)
+    end
+
+    let(:arguments) { Rake::TaskArguments.new(%i[ccms_code], [ccms_code]) }
+
+    before do
+      Rails.application.load_tasks if Rake::Task.tasks.empty?
+
+      # prevent output in test suite
+      allow($stdout).to receive(:puts)
+
+      # say yes to any prompted output
+      allow($stdin).to receive(:gets).and_return "yes"
+    end
+
+    context "with a non-existent proceeding type ccms code" do
+      let(:ccms_code) { "SE099E" }
+
+      it "does not delete any proceedings" do
+        expect { run }.not_to change(ProceedingType, :count)
+      end
+
+      it "outputs not found message" do
+        run
+        expect($stdout).to have_received(:puts).with("ProceedingType SE099E not found!")
+      end
+    end
+
+    context "with existing proceeding type matching the ccms code" do
+      let(:ccms_code) { "SE099E" }
+
+      before do
+        create(:proceeding_type,
+               ccms_code: "SE099E",
+               meaning: "Amd enforcement-breach-S8",
+               description: "whatever description",
+               matter_type: MatterType.find_by(code: "KSEC8"))
+      end
+
+      it "deletes the proceeding" do
+        expect { run }.to change(ProceedingType, :count).by(-1)
+      end
+
+      it "outputs success message" do
+        run
+        expect($stdout).to have_received(:puts).with("Deleted proceeding_type SE099E with meaning \"Amd enforcement-breach-S8\"")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What
Remove unused proceeding SE099E

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5603)

It was removed 9 September 2024. [commit here](https://github.com/ministryofjustice/legal-framework-api/pull/1419/commits/f61f9d4bd51e67c6fc197361487ef3768dbcf515) but is still in the database on main uat, staging and production.

## Also
I identified some no longer existing relations to the table and model, `proceeding_type_scope_limitations`, which was deleted 2 years ago. These have been removed in a separate commit.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
