### PR TITLE
AP-5603: fix typos in rake task

### DIFF
--- a/lib/tasks/fixes/ap_5603.rake
+++ b/lib/tasks/fixes/ap_5603.rake
@@ -1,5 +1,5 @@
 namespace :fixes do
-  desc "Remove an proceeding type"
+  desc "Remove a proceeding type"
   task :remove_proceeding_type, [:ccms_code] => :environment do |_task, args|
     proceeding_type = ProceedingType.find_by(ccms_code: args[:ccms_code])
     puts "----------------------------------------------------------"
@@ -32,7 +32,7 @@ namespace :fixes do
     puts "----------------------------------------------------------"
   end
 
-  desc "AP-55603: remove unused proceeding type SE099E"
+  desc "AP-5603: remove unused proceeding type SE099E"
   task remove_proceeding_type_SE099E: :environment do
     Rake::Task["fixes:remove_proceeding_type"].execute(ccms_code: "SE099E")
   end


### PR DESCRIPTION

## What
Fix typs in rake task

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5603)


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
