### PR TITLE
AP-5727: Update proceeding type filter 

### DIFF
--- a/app/services/proceeding_type_filter.rb
+++ b/app/services/proceeding_type_filter.rb
@@ -37,13 +37,17 @@ private
   end
 
   def configure_plf_proceedings!
-    return unless current_proceedings_have_plf
+    if current_proceedings_have_plf
+      @results.delete_if do |proceeding|
+        [
+          proceeding_is_not_plf?(proceeding), # if already has an PLF proceeding, exclude all non-PLF proceedings
+          has_means_test_plf_mismatch?(proceeding),
+        ].any?
+      end
+    else
+      return if @current_proceedings.empty?
 
-    @results.delete_if do |proceeding|
-      [
-        proceeding_is_not_plf?(proceeding), # if already has an PLF proceeding, exclude all non-PLF proceedings
-        has_means_test_plf_mismatch?(proceeding),
-      ].any?
+      @results.delete_if { |proceeding| proceeding["ccms_code"].match?("^PBM") }
     end
   end
 

--- a/spec/services/proceeding_type_filter_spec.rb
+++ b/spec/services/proceeding_type_filter_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe ProceedingTypeFilter do
     context "and it has a non-SCA proceeding" do
       let(:current_proceedings) { %w[DA001] }
 
-      it "returns all proceedings minus the current one and sca_related proceedings" do
-        expect(proceeding_type_filter.count).to eq 134
+      it "returns all proceedings excluding the current one, all PLF and all sca_related proceedings" do
+        expect(proceeding_type_filter.count).to eq 39
+        expect(proceeding_type_filter.pluck("ccms_matter_code").uniq).not_to include "KPBLB"
+        expect(proceeding_type_filter.pluck("sca_related").uniq).not_to include true
       end
     end
 
@@ -33,8 +35,9 @@ RSpec.describe ProceedingTypeFilter do
     context "and it has a means tested PLF proceeding" do
       let(:current_proceedings) { %w[PBM04] }
 
-      it "returns only PLF proceedings minus the current one" do
+      it "returns only PLF proceedings minus the current one and the non_means_tested ones" do
         expect(proceeding_type_filter.pluck("ccms_matter_code").uniq).to eq %w[KPBLB]
+        expect(proceeding_type_filter.pluck("non_means_tested_plf").uniq).to eq [false]
         expect(proceeding_type_filter.count).to eq 90
       end
     end
@@ -45,6 +48,7 @@ RSpec.describe ProceedingTypeFilter do
       it "returns only the other non means tested PLF proceedings" do
         expect(proceeding_type_filter.pluck("ccms_matter_code").uniq).to eq %w[KPBLB]
         expect(proceeding_type_filter.pluck("ccms_code").uniq).to match_array %w[PBM45 PBM40E PBM45E]
+        expect(proceeding_type_filter.pluck("non_means_tested_plf").uniq).to eq [true]
         expect(proceeding_type_filter.count).to eq 3
       end
     end


### PR DESCRIPTION


## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-5727)

When a non PLF proceeding is present, no PLF proceedings should be returned.  

This is in addition to the means/non-means PLF filtering already in place

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
