### PR TITLE
Chore: Replace PLF vary order merits task

### DIFF
--- a/db/seed_data/proceeding_type_merits_task/public_law_family.yml
+++ b/db/seed_data/proceeding_type_merits_task/public_law_family.yml
@@ -57,7 +57,7 @@
     - defendant_on_this_proceeding:
       - opponents_application
     - court_order_copy
-    - plf_vary_order
+    - vary_order
 - ccms_code: "PBM06"
   questions:
     - opponent_name
@@ -86,7 +86,7 @@
     - defendant_on_this_proceeding:
       - opponents_application
     - court_order_copy
-    - plf_vary_order
+    - vary_order
     - applicant_on_this_proceeding:
       - client_child_care_assessment
 - ccms_code: "PBM08"
@@ -388,7 +388,7 @@
     - defendant_on_this_proceeding:
       - opponents_application
     - court_order_copy
-    - plf_vary_order
+    - vary_order
 - ccms_code: "PBM35"
   questions:
     - opponent_name

--- a/spec/services/questions_service_spec.rb
+++ b/spec/services/questions_service_spec.rb
@@ -438,16 +438,16 @@ RSpec.describe QuestionsService do
       context "when proceeding type relates to a Contact with a child in care" do
         let(:ccms_code) { "PBM05" }
 
-        it "adds plf_vary_order to ProceedingTask" do
-          expect(proceeding_tasks_for_ccms_code).to include({ "plf_vary_order" => [] })
+        it "adds vary_order to ProceedingTask" do
+          expect(proceeding_tasks_for_ccms_code).to include({ "vary_order" => [] })
         end
       end
 
       context "when proceeding type relates to a Care order - discharge" do
         let(:ccms_code) { "PBM07" }
 
-        it "adds plf_vary_order to ProceedingTask" do
-          expect(proceeding_tasks_for_ccms_code).to include({ "plf_vary_order" => [] })
+        it "adds vary_order to ProceedingTask" do
+          expect(proceeding_tasks_for_ccms_code).to include({ "vary_order" => [] })
         end
 
         context "and client involvement type is Applicant" do
@@ -470,8 +470,8 @@ RSpec.describe QuestionsService do
       context "when proceeding type relates to a Revocation placement order" do
         let(:ccms_code) { "PBM33" }
 
-        it "adds plf_vary_order to ProceedingTask" do
-          expect(proceeding_tasks_for_ccms_code).to include({ "plf_vary_order" => [] })
+        it "adds vary_order to ProceedingTask" do
+          expect(proceeding_tasks_for_ccms_code).to include({ "vary_order" => [] })
         end
       end
 


### PR DESCRIPTION
## What
Replace PLF vary order merits task

[Leftover from story](https://dsdmoj.atlassian.net/browse/AP-4414)

Replace plf_vary_order merits tasks with existing vary_order merits
task and delete the plf_vary_order merits_task. 

It was originally thought that this question may be different from the same
question for different matter types. Design changed the question to be suitable
for any matter type and hence this merits_task has never been wired up in Civil Apply. 

> [!WARNING]  
> Without this change the PLF proceedings PBM05, 07 and 33 do not currently get the question added to their merits 
task list when they should.

Testing: The proceeding_merits_task_list join table records were destroyed by the removal of the relations. The merits_task has deliberately not been destroyed in this PR for safety - to avoid potential seeding errors resulting from order of seeding. It will be deleted in a subsequent PR.

Can be tested on [this branch of civil apply](https://test-vary-order-for-plf-applyforlegalaid-uat.cloud-platform.service.justice.gov.uk/)

## TODO
`plf_var_order` merits task will be deleted in a subsequent PR

## Before
Using main branch of civil apply and LFA

<img width="712" alt="Screenshot 2025-02-14 at 11 41 06" src="https://github.com/user-attachments/assets/904360c9-cd2f-4b7e-b8cb-e1a4469f196c" />


## After
Using a branch of civl apply wired up to this branch

<img width="712" alt="Screenshot 2025-02-14 at 11 39 50" src="https://github.com/user-attachments/assets/318cfa43-448a-4843-898c-a8817bce4c6f" />


## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
