### PR TITLE
Chore: Delete unused plf_vary_order merits task

### DIFF
--- a/db/populators/merits_task_populator.rb
+++ b/db/populators/merits_task_populator.rb
@@ -25,7 +25,6 @@ class MeritsTaskPopulator
     opponents_application
     vary_order
     client_relationship_to_proceeding
-    plf_vary_order
     client_child_care_assessment
   ].freeze
 

--- a/spec/populators/merits_task_populator_spec.rb
+++ b/spec/populators/merits_task_populator_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe MeritsTaskPopulator do
       opponents_application
       vary_order
       client_relationship_to_proceeding
-      plf_vary_order
       client_child_care_assessment
     ]
   end
@@ -51,7 +50,7 @@ RSpec.describe MeritsTaskPopulator do
       end
 
       it "seeds all merits tasks" do
-        expect { call }.to change(MeritsTask, :count).from(0).to(24)
+        expect { call }.to change(MeritsTask, :count).from(0).to(23)
         expect(MeritsTask.pluck(:name)).to match_array(merits_tasks)
       end
     end
@@ -80,7 +79,7 @@ RSpec.describe MeritsTaskPopulator do
       end
 
       it "removes the merits tasks that are no longer seeded" do
-        expect { call }.to change(MeritsTask, :count).from(24).to(2)
+        expect { call }.to change(MeritsTask, :count).from(23).to(2)
       end
     end
   end


### PR DESCRIPTION
## What
Delete plf_vary_order merits task

[Leftover from story](https://dsdmoj.atlassian.net/browse/AP-4414)

Following [the replacement PR](https://github.com/ministryofjustice/legal-framework-api/pull/1545) the `plf_vary_order` merits task is no longer associated with any proceedings. 

This was previously associated with proceedings PBM05, 07 and 33
but has since been replaced by the standard vary_order merits task. 
This is because designers have changed the content for the question 
in Civil Apply such that the standard question can be used for all 
applicable matter type proceedings.

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
