### PR TITLE
Chore: update values-staging to add scheduled downtime

### DIFF
--- a/deploy/helm/values-staging.yaml
+++ b/deploy/helm/values-staging.yaml
@@ -25,3 +25,6 @@ deploy:
 
 postgresql:
   enabled: false
+
+scheduledDowntime:
+  enabled: true


### PR DESCRIPTION
## What

Currently, we turn off RDS at night for non prod environments but we don't have scheduled downtime for the pods. A PR is open to make the relevant changes to cloud platform environment here: https://github.com/ministryofjustice/cloud-platform-environments/pull/32690. This PR updates `values-staging` to add the relevant changes to this repo

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
