### PR TITLE
Chore: Regenerate swagger docs

### DIFF
--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -979,14 +979,14 @@ paths:
                     ccms_opponent_id: '280367'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Ashford Borough Council
-                    ccms_opponent_id: '280368'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: Ashford and St Peter’s Hospitals NHS Foundation Trust
                     ccms_opponent_id: '380761'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Ashford Borough Council
+                    ccms_opponent_id: '280368'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Ashton, Leigh and Wigan PCT
                     ccms_opponent_id: '380762'
                     ccms_type_text: National Health Service
@@ -1039,12 +1039,12 @@ paths:
                     ccms_opponent_id: '280373'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Barking Havering & Redbridge Hospitals NHS Trust
-                    ccms_opponent_id: '380775'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Barking and Dagenham PCT
                     ccms_opponent_id: '380774'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: Barking Havering & Redbridge Hospitals NHS Trust
+                    ccms_opponent_id: '380775'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Barnet & Chase Farm Hospitals NHS Trust
@@ -1083,14 +1083,14 @@ paths:
                     ccms_opponent_id: '380794'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: Basildon Borough Council
-                    ccms_opponent_id: '280376'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: Basildon and Thurrock University Hospitals NHS Trust
                     ccms_opponent_id: '380795'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Basildon Borough Council
+                    ccms_opponent_id: '280376'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Basingstoke and Deane Borough Council
                     ccms_opponent_id: '280377'
                     ccms_type_text: Local Authority
@@ -1151,6 +1151,10 @@ paths:
                     ccms_opponent_id: '381463'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Birmingham and Solihull Mental Health NHS Foundation Trust
+                    ccms_opponent_id: '380803'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Birmingham Children's Hospital NHS Foundation Trust
                     ccms_opponent_id: '380804'
                     ccms_type_text: National Health Service
@@ -1175,10 +1179,6 @@ paths:
                     ccms_opponent_id: '380808'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: Birmingham and Solihull Mental Health NHS Foundation Trust
-                    ccms_opponent_id: '380803'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Blaby District Council
                     ccms_opponent_id: '280383'
                     ccms_type_text: Local Authority
@@ -1187,14 +1187,14 @@ paths:
                     ccms_opponent_id: '380809'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: Blackburn With Darwen Teaching Care Trust Plus
-                    ccms_opponent_id: '380810'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Blackburn with Darwen Borough Council
                     ccms_opponent_id: '280384'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: Blackburn With Darwen Teaching Care Trust Plus
+                    ccms_opponent_id: '380810'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Blackpool Council
                     ccms_opponent_id: '280385'
                     ccms_type_text: Local Authority
@@ -1247,14 +1247,14 @@ paths:
                     ccms_opponent_id: '280390'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Bournemouth Borough Council
-                    ccms_opponent_id: '280391'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: Bournemouth and Poole Teaching PCT
                     ccms_opponent_id: '380815'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Bournemouth Borough Council
+                    ccms_opponent_id: '280391'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Bracknell Forest Borough Council
                     ccms_opponent_id: '280392'
                     ccms_type_text: Local Authority
@@ -1263,16 +1263,16 @@ paths:
                     ccms_opponent_id: '380816'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Bradford and Airedale Teaching PCT
+                    ccms_opponent_id: '380817'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Bradford District Care Trust
                     ccms_opponent_id: '380818'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Bradford Teaching Hospitals NHS Foundation Trust
                     ccms_opponent_id: '380819'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: Bradford and Airedale Teaching PCT
-                    ccms_opponent_id: '380817'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Braintree District Council
@@ -1455,6 +1455,10 @@ paths:
                     ccms_opponent_id: '380835'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Cambridgeshire and Peterborough NHS Foundation Trust
+                    ccms_opponent_id: '380836'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cambridgeshire Community Services NHS Trust
                     ccms_opponent_id: '380837'
                     ccms_type_text: National Health Service
@@ -1471,10 +1475,6 @@ paths:
                     ccms_opponent_id: '381466'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
-                  - name: Cambridgeshire and Peterborough NHS Foundation Trust
-                    ccms_opponent_id: '380836'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Camden PCT
                     ccms_opponent_id: '380839'
                     ccms_type_text: National Health Service
@@ -1531,6 +1531,10 @@ paths:
                     ccms_opponent_id: '380841'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Central and North West London NHS Foundation Trust
+                    ccms_opponent_id: '380843'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Central Bedfordshire Council
                     ccms_opponent_id: '282438'
                     ccms_type_text: Local Authority
@@ -1555,10 +1559,6 @@ paths:
                     ccms_opponent_id: '381467'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
-                  - name: Central and North West London NHS Foundation Trust
-                    ccms_opponent_id: '380843'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Centre for Environment, Fisheries and Aquaculture Science
                     ccms_opponent_id: '378766'
                     ccms_type_text: Government Department
@@ -1595,6 +1595,10 @@ paths:
                     ccms_opponent_id: '282342'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: Cheshire and Wirral Partnership NHS Foundation Trust
+                    ccms_opponent_id: '380848'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cheshire East Council
                     ccms_opponent_id: '283351'
                     ccms_type_text: Local Authority
@@ -1607,10 +1611,6 @@ paths:
                     ccms_opponent_id: '281370'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Cheshire and Wirral Partnership NHS Foundation Trust
-                    ccms_opponent_id: '380848'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Chesterfield Borough Council
                     ccms_opponent_id: '281371'
                     ccms_type_text: Local Authority
@@ -1639,16 +1639,16 @@ paths:
                     ccms_opponent_id: '282440'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: City Hospitals Sunderland NHS Foundation Trust
-                    ccms_opponent_id: '380851'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: City and County of Swansea
                     ccms_opponent_id: '282439'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
                   - name: City and Hackney Teaching PCT
                     ccms_opponent_id: '380850'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: City Hospitals Sunderland NHS Foundation Trust
+                    ccms_opponent_id: '380851'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: City of Bradford Metropolitan District Council
@@ -1731,16 +1731,16 @@ paths:
                     ccms_opponent_id: '282353'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: Cornwall and Isles of Scilly PCT
+                    ccms_opponent_id: '380853'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Cornwall Council
                     ccms_opponent_id: '282354'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
                   - name: Cornwall Partnership NHS Foundation Trust
                     ccms_opponent_id: '380854'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: Cornwall and Isles of Scilly PCT
-                    ccms_opponent_id: '380853'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Cotswold District Council
@@ -1759,16 +1759,16 @@ paths:
                     ccms_opponent_id: '380856'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Coventry and Warwickshire Partnership NHS Trust
+                    ccms_opponent_id: '380858'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Coventry City Council
                     ccms_opponent_id: '282357'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
                   - name: Coventry PCT
                     ccms_opponent_id: '380859'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: Coventry and Warwickshire Partnership NHS Trust
-                    ccms_opponent_id: '380858'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Craigavon Borough Council
@@ -1831,14 +1831,14 @@ paths:
                     ccms_opponent_id: '380865'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: Dartford Borough Council
-                    ccms_opponent_id: '282364'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: Dartford and Gravesham NHS Hospital Trust
                     ccms_opponent_id: '380866'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Dartford Borough Council
+                    ccms_opponent_id: '282364'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Dartmoor
                     ccms_opponent_id: '378978'
                     ccms_type_text: HM Prison or Young Offender Institute
@@ -1955,12 +1955,12 @@ paths:
                     ccms_opponent_id: '281376'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Devon PCT
-                    ccms_opponent_id: '380885'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Devon Partnership NHS Trust
                     ccms_opponent_id: '380884'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: Devon PCT
+                    ccms_opponent_id: '380885'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Diana Princess of Wales Hospital
@@ -2031,16 +2031,16 @@ paths:
                     ccms_opponent_id: '378787'
                     ccms_type_text: Government Department
                     ccms_type_code: GOVT
+                  - name: Dudley and Walsall Mental Health Partnership NHS Trust
+                    ccms_opponent_id: '380892'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Dudley Metropolitan Borough Council
                     ccms_opponent_id: '281380'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
                   - name: Dudley PCT
                     ccms_opponent_id: '380893'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: Dudley and Walsall Mental Health Partnership NHS Trust
-                    ccms_opponent_id: '380892'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Dumfries & Galloway Police HQ
@@ -2160,6 +2160,18 @@ paths:
                     ccms_opponent_id: '281397'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: East of England Ambulance Service NHS Trust
+                    ccms_opponent_id: '380907'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: East of England Government Office Region
+                    ccms_opponent_id: '378793'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
+                  - name: East of England Strategic Health Authority
+                    ccms_opponent_id: '380908'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: East Renfrewshire Council
                     ccms_opponent_id: '281399'
                     ccms_type_text: Local Authority
@@ -2184,18 +2196,6 @@ paths:
                     ccms_opponent_id: '378982'
                     ccms_type_text: HM Prison or Young Offender Institute
                     ccms_type_code: HMO
-                  - name: East of England Ambulance Service NHS Trust
-                    ccms_opponent_id: '380907'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: East of England Government Office Region
-                    ccms_opponent_id: '378793'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
-                  - name: East of England Strategic Health Authority
-                    ccms_opponent_id: '380908'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Eastbourne Borough Council
                     ccms_opponent_id: '281403'
                     ccms_type_text: Local Authority
@@ -2268,10 +2268,6 @@ paths:
                     ccms_opponent_id: '281413'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: FCO Services
-                    ccms_opponent_id: '378797'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
                   - name: Fairfield NHS
                     ccms_opponent_id: '380921'
                     ccms_type_text: National Health Service
@@ -2288,6 +2284,10 @@ paths:
                     ccms_opponent_id: '281417'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: FCO Services
+                    ccms_opponent_id: '378797'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Featherstone
                     ccms_opponent_id: '378988'
                     ccms_type_text: HM Prison or Young Offender Institute
@@ -2344,14 +2344,14 @@ paths:
                     ccms_opponent_id: '281423'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Forest Research
-                    ccms_opponent_id: '378812'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
                   - name: Forest of Dean District Council
                     ccms_opponent_id: '281424'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: Forest Research
+                    ccms_opponent_id: '378812'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Forestry Commission
                     ccms_opponent_id: '378813'
                     ccms_type_text: Government Department
@@ -2528,26 +2528,6 @@ paths:
                     ccms_opponent_id: '280404'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: HM Courts Service
-                    ccms_opponent_id: '378820'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
-                  - name: HM Land Registry
-                    ccms_opponent_id: '378821'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
-                  - name: HM Revenue and Customs
-                    ccms_opponent_id: '378822'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
-                  - name: HM Treasury
-                    ccms_opponent_id: '378823'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
-                  - name: HM Treasury Correspondence & Enquiry Unit
-                    ccms_opponent_id: '378824'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
                   - name: Halton & St Helens PCT Widnes Health Care Resource Centre
                     ccms_opponent_id: '380938'
                     ccms_type_text: National Health Service
@@ -2560,12 +2540,12 @@ paths:
                     ccms_opponent_id: '280406'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Hammersmith Hospital NHS Trust
-                    ccms_opponent_id: '380949'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Hammersmith and Fulham PCT
                     ccms_opponent_id: '380948'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: Hammersmith Hospital NHS Trust
+                    ccms_opponent_id: '380949'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Hampshire Constabulary
@@ -2632,14 +2612,14 @@ paths:
                     ccms_opponent_id: '380750'
                     ccms_type_text: Immigration Removal Centre
                     ccms_type_code: IRC
-                  - name: Hastings Borough Council
-                    ccms_opponent_id: '281342'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: Hastings and Rother PCT
                     ccms_opponent_id: '380957'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Hastings Borough Council
+                    ccms_opponent_id: '281342'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Havant Borough Council
                     ccms_opponent_id: '281345'
                     ccms_type_text: Local Authority
@@ -2692,12 +2672,12 @@ paths:
                     ccms_opponent_id: '281347'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Hertfordshire PCT
-                    ccms_opponent_id: '380968'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Hertfordshire Partnership NHS Foundation Trust
                     ccms_opponent_id: '380967'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: Hertfordshire PCT
+                    ccms_opponent_id: '380968'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Hertfordshire Police HQ
@@ -2752,6 +2732,26 @@ paths:
                     ccms_opponent_id: '379022'
                     ccms_type_text: HM Prison or Young Offender Institute
                     ccms_type_code: HMO
+                  - name: HM Courts Service
+                    ccms_opponent_id: '378820'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
+                  - name: HM Land Registry
+                    ccms_opponent_id: '378821'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
+                  - name: HM Revenue and Customs
+                    ccms_opponent_id: '378822'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
+                  - name: HM Treasury
+                    ccms_opponent_id: '378823'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
+                  - name: HM Treasury Correspondence & Enquiry Unit
+                    ccms_opponent_id: '378824'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Hollesley Bay
                     ccms_opponent_id: '379023'
                     ccms_type_text: HM Prison or Young Offender Institute
@@ -2772,24 +2772,24 @@ paths:
                     ccms_opponent_id: '281352'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Hounslow PCT
-                    ccms_opponent_id: '380974'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Hounslow and Richmond Community Healthcare NHS Trust
                     ccms_opponent_id: '380973'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: Hounslow PCT
+                    ccms_opponent_id: '380974'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Housing Hartlepool
                     ccms_opponent_id: '380738'
                     ccms_type_text: Housing Association
                     ccms_type_code: HOA
-                  - name: Hull Teaching PCT
-                    ccms_opponent_id: '380995'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Hull and East Yorkshire Hospitals NHS Trust
                     ccms_opponent_id: '380994'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: Hull Teaching PCT
+                    ccms_opponent_id: '380995'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Humber NHS Trust
@@ -2868,10 +2868,6 @@ paths:
                     ccms_opponent_id: '378828'
                     ccms_type_text: Government Department
                     ccms_type_code: GOVT
-                  - name: Kensington Housing Trust
-                    ccms_opponent_id: '380739'
-                    ccms_type_text: Housing Association
-                    ccms_type_code: HOA
                   - name: Kensington and Chelsea PCT
                     ccms_opponent_id: '381004'
                     ccms_type_text: National Health Service
@@ -2880,6 +2876,14 @@ paths:
                     ccms_opponent_id: '378829'
                     ccms_type_text: Government Department
                     ccms_type_code: GOVT
+                  - name: Kensington Housing Trust
+                    ccms_opponent_id: '380739'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
+                  - name: Kent and Medway NHS and Social Care Partnership Trust
+                    ccms_opponent_id: '381005'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Kent Community Health NHS Trust
                     ccms_opponent_id: '381006'
                     ccms_type_text: National Health Service
@@ -2892,10 +2896,6 @@ paths:
                     ccms_opponent_id: '381497'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
-                  - name: Kent and Medway NHS and Social Care Partnership Trust
-                    ccms_opponent_id: '381005'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Kettering Borough Council
                     ccms_opponent_id: '281360'
                     ccms_type_text: Local Authority
@@ -3000,6 +3000,10 @@ paths:
                     ccms_opponent_id: '379029'
                     ccms_type_text: Charity
                     ccms_type_code: CHAR
+                  - name: Leeds and York Partnership NHS Foundation Trust
+                    ccms_opponent_id: '381019'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Leeds City County Council
                     ccms_opponent_id: '281368'
                     ccms_type_text: Local Authority
@@ -3020,10 +3024,6 @@ paths:
                     ccms_opponent_id: '381024'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: Leeds and York Partnership NHS Foundation Trust
-                    ccms_opponent_id: '381019'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Leicester City PCT
                     ccms_opponent_id: '381025'
                     ccms_type_text: National Health Service
@@ -3036,14 +3036,14 @@ paths:
                     ccms_opponent_id: '381499'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
-                  - name: Leicestershire County Council
-                    ccms_opponent_id: '281422'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: Leicestershire County and Rutland PCT
                     ccms_opponent_id: '381027'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Leicestershire County Council
+                    ccms_opponent_id: '281422'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Leicestershire Partnership NHS Trust
                     ccms_opponent_id: '381028'
                     ccms_type_text: National Health Service
@@ -3128,6 +3128,10 @@ paths:
                     ccms_opponent_id: '381039'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: London and Quadrant Housing Association
+                    ccms_opponent_id: '380740'
+                    ccms_type_text: Housing Association
+                    ccms_type_code: HOA
                   - name: London Borough of Barking and Dagenham Council
                     ccms_opponent_id: '281394'
                     ccms_type_text: Local Authority
@@ -3244,10 +3248,6 @@ paths:
                     ccms_opponent_id: '381040'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: London and Quadrant Housing Association
-                    ccms_opponent_id: '380740'
-                    ccms_type_text: Housing Association
-                    ccms_type_code: HOA
                   - name: Long Lartin
                     ccms_opponent_id: '379033'
                     ccms_type_text: HM Prison or Young Offender Institute
@@ -3276,14 +3276,6 @@ paths:
                     ccms_opponent_id: '381042'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: MI5 (director General of Security)
-                    ccms_opponent_id: '378836'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
-                  - name: MI6 (secret Intelligence Service)
-                    ccms_opponent_id: '378837'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
                   - name: Magherafelt District Council
                     ccms_opponent_id: '281465'
                     ccms_type_text: Local Authority
@@ -3377,6 +3369,14 @@ paths:
                     ccms_opponent_id: '381517'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
+                  - name: MI5 (director General of Security)
+                    ccms_opponent_id: '378836'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
+                  - name: MI6 (secret Intelligence Service)
+                    ccms_opponent_id: '378837'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Mid Cheshire NHS Trust
                     ccms_opponent_id: '381093'
                     ccms_type_text: National Health Service
@@ -3486,14 +3486,6 @@ paths:
                     ccms_opponent_id: '281497'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: NHS Blood 7 Transport
-                    ccms_opponent_id: '378847'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
-                  - name: NHS Direct NHS Trust
-                    ccms_opponent_id: '381106'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: National Archives
                     ccms_opponent_id: '378841'
                     ccms_type_text: Government Department
@@ -3510,16 +3502,16 @@ paths:
                     ccms_opponent_id: '378844'
                     ccms_type_text: Government Department
                     ccms_type_code: GOVT
+                  - name: National offender Management Service (noms)
+                    ccms_opponent_id: '378845'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: National Policing Improvement Agency
                     ccms_opponent_id: '381518'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
                   - name: National School of Government
                     ccms_opponent_id: '378846'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
-                  - name: National offender Management Service (noms)
-                    ccms_opponent_id: '378845'
                     ccms_type_text: Government Department
                     ccms_type_code: GOVT
                   - name: Neath Port Talbot County Borough Council
@@ -3550,10 +3542,6 @@ paths:
                     ccms_opponent_id: '381102'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: Newcastle Upon Tyne Hospitals NHS Foundation Trust
-                    ccms_opponent_id: '381103'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Newcastle under Lyme Borough Council
                     ccms_opponent_id: '281505'
                     ccms_type_text: Local Authority
@@ -3562,6 +3550,10 @@ paths:
                     ccms_opponent_id: '281507'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: Newcastle Upon Tyne Hospitals NHS Foundation Trust
+                    ccms_opponent_id: '381103'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Newham PCT
                     ccms_opponent_id: '381104'
                     ccms_type_text: National Health Service
@@ -3582,8 +3574,20 @@ paths:
                     ccms_opponent_id: '281512'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: NHS Blood 7 Transport
+                    ccms_opponent_id: '378847'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
+                  - name: NHS Direct NHS Trust
+                    ccms_opponent_id: '381106'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Norfolk & Norwich NHS Trust
                     ccms_opponent_id: '381107'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: Norfolk and Suffolk NHS Foundation Trust
+                    ccms_opponent_id: '381108'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Norfolk Community Health and Care NHS Trust
@@ -3600,10 +3604,6 @@ paths:
                     ccms_type_code: POLICE
                   - name: Norfolk Primary Care Trust
                     ccms_opponent_id: '381110'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: Norfolk and Suffolk NHS Foundation Trust
-                    ccms_opponent_id: '381108'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: North Ayrshire Council
@@ -4326,10 +4326,6 @@ paths:
                     ccms_opponent_id: '281527'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: SOCA
-                    ccms_opponent_id: '381552'
-                    ccms_type_text: Police Authority
-                    ccms_type_code: POLICE
                   - name: Salford City Council
                     ccms_opponent_id: '281529'
                     ccms_type_text: Local Authority
@@ -4350,16 +4346,16 @@ paths:
                     ccms_opponent_id: '381220'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Sandwell and West Birmingham Hospitals NHS Trust
+                    ccms_opponent_id: '381221'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Sandwell Metropolitan Borough Council
                     ccms_opponent_id: '281532'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
                   - name: Sandwell PCT
                     ccms_opponent_id: '381222'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: Sandwell and West Birmingham Hospitals NHS Trust
-                    ccms_opponent_id: '381221'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Scarborough & North East Yorkshire NHS Trust
@@ -4382,10 +4378,6 @@ paths:
                     ccms_opponent_id: '381551'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
-                  - name: Secretary of State Home Department
-                    ccms_opponent_id: '378875'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
                   - name: Secretary of State for Defence War Office
                     ccms_opponent_id: '378873'
                     ccms_type_text: Government Department
@@ -4394,6 +4386,10 @@ paths:
                     ccms_opponent_id: '378874'
                     ccms_type_text: Charity
                     ccms_type_code: CHAR
+                  - name: Secretary of State Home Department
+                    ccms_opponent_id: '378875'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
                   - name: Sedgemoor District Council
                     ccms_opponent_id: '281538'
                     ccms_type_text: Local Authority
@@ -4491,6 +4487,10 @@ paths:
                     ccms_opponent_id: '281555'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: SOCA
+                    ccms_opponent_id: '381552'
+                    ccms_type_text: Police Authority
+                    ccms_type_code: POLICE
                   - name: Solent NHS Trust
                     ccms_opponent_id: '381238'
                     ccms_type_text: National Health Service
@@ -4635,17 +4635,17 @@ paths:
                     ccms_opponent_id: '281593'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: South Staffordshire and Shropshire Healthcare NHS Foundation
+                      Trust
+                    ccms_opponent_id: '381255'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: South Staffordshire Council
                     ccms_opponent_id: '281594'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
                   - name: South Staffordshire PCT
                     ccms_opponent_id: '381256'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: South Staffordshire and Shropshire Healthcare NHS Foundation
-                      Trust
-                    ccms_opponent_id: '381255'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: South Tees NHS Trust
@@ -4712,14 +4712,14 @@ paths:
                     ccms_opponent_id: '381267'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: Southend University Hospital NHS Trust
-                    ccms_opponent_id: '381268'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Southend on Sea Borough Council
                     ccms_opponent_id: '281596'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: Southend University Hospital NHS Trust
+                    ccms_opponent_id: '381268'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Southern Health NHS Foundation Trust
                     ccms_opponent_id: '381269'
                     ccms_type_text: National Health Service
@@ -4764,18 +4764,22 @@ paths:
                     ccms_opponent_id: '381274'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: St Helens Metropolitan Borough Council
-                    ccms_opponent_id: '281600'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: St Helens and Knowsley Hospitals NHS Trust
                     ccms_opponent_id: '381275'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: St Helens Metropolitan Borough Council
+                    ccms_opponent_id: '281600'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Stafford Borough Council
                     ccms_opponent_id: '281601'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: Staffordshire and Stoke On Trent Partnership NHS Trust
+                    ccms_opponent_id: '381277'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Staffordshire County Council
                     ccms_opponent_id: '281602'
                     ccms_type_text: Local Authority
@@ -4788,10 +4792,6 @@ paths:
                     ccms_opponent_id: '381556'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
-                  - name: Staffordshire and Stoke On Trent Partnership NHS Trust
-                    ccms_opponent_id: '381277'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Standford Hill
                     ccms_opponent_id: '380690'
                     ccms_type_text: HM Prison or Young Offender Institute
@@ -4836,14 +4836,14 @@ paths:
                     ccms_opponent_id: '380719'
                     ccms_type_text: HM Prison or Young Offender Institute
                     ccms_type_code: HMO
-                  - name: Stoke On Trent PCT
-                    ccms_opponent_id: '381282'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Stoke on Trent City Council
                     ccms_opponent_id: '281608'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
+                  - name: Stoke On Trent PCT
+                    ccms_opponent_id: '381282'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Strabane District Council
                     ccms_opponent_id: '281609'
                     ccms_type_text: Local Authority
@@ -4896,6 +4896,10 @@ paths:
                     ccms_opponent_id: '381286'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Surrey and Borders Partnership NHS Foundation Trust
+                    ccms_opponent_id: '381287'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Surrey County Council
                     ccms_opponent_id: '281615'
                     ccms_type_text: Local Authority
@@ -4912,10 +4916,6 @@ paths:
                     ccms_opponent_id: '381559'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
-                  - name: Surrey and Borders Partnership NHS Foundation Trust
-                    ccms_opponent_id: '381287'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Sussex Community NHS Trust
                     ccms_opponent_id: '381289'
                     ccms_type_text: National Health Service
@@ -4956,6 +4956,10 @@ paths:
                     ccms_opponent_id: '380722'
                     ccms_type_text: HM Prison or Young Offender Institute
                     ccms_type_code: HMO
+                  - name: Tameside and Glossop PCT
+                    ccms_opponent_id: '381294'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Tameside Hospital NHS Foundation Trust
                     ccms_opponent_id: '381295'
                     ccms_type_text: National Health Service
@@ -4964,10 +4968,6 @@ paths:
                     ccms_opponent_id: '281621'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Tameside and Glossop PCT
-                    ccms_opponent_id: '381294'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: Tamworth Borough Council
                     ccms_opponent_id: '281622'
                     ccms_type_text: Local Authority
@@ -4976,14 +4976,14 @@ paths:
                     ccms_opponent_id: '281623'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Taunton Deane Borough Council
-                    ccms_opponent_id: '281624'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: Taunton and Somerset NHS Foundation Trust
                     ccms_opponent_id: '381296'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Taunton Deane Borough Council
+                    ccms_opponent_id: '281624'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Tavistock and Portman NHS Foundation Trust
                     ccms_opponent_id: '381317'
                     ccms_type_text: National Health Service
@@ -5130,14 +5130,14 @@ paths:
                     ccms_opponent_id: '281640'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
-                  - name: Torbay Council
-                    ccms_opponent_id: '281642'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: Torbay and Southern Devon Health and Care NHS Trust
                     ccms_opponent_id: '381373'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Torbay Council
+                    ccms_opponent_id: '281642'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Torfaen County Borough Council
                     ccms_opponent_id: '281644'
                     ccms_type_text: Local Authority
@@ -5218,16 +5218,16 @@ paths:
                     ccms_opponent_id: '381383'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
-                  - name: University Hospital Southampton NHS Foundation Trust
-                    ccms_opponent_id: '381386'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
                   - name: University Hospital of North Staffordshire NHS Trust
                     ccms_opponent_id: '381384'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: University Hospital of South Manchester
                     ccms_opponent_id: '381385'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
+                  - name: University Hospital Southampton NHS Foundation Trust
+                    ccms_opponent_id: '381386'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: University Hospitals Birmingham NHS Foundation Trust
@@ -5270,12 +5270,12 @@ paths:
                     ccms_opponent_id: '378911'
                     ccms_type_text: Government Department
                     ccms_type_code: GOVT
-                  - name: Vehicle Certification Agency
-                    ccms_opponent_id: '378913'
-                    ccms_type_text: Government Department
-                    ccms_type_code: GOVT
                   - name: Vehicle and Operator Services Agency
                     ccms_opponent_id: '378912'
+                    ccms_type_text: Government Department
+                    ccms_type_code: GOVT
+                  - name: Vehicle Certification Agency
+                    ccms_opponent_id: '378913'
                     ccms_type_text: Government Department
                     ccms_type_code: GOVT
                   - name: Velindre NHS Trust
@@ -5330,16 +5330,16 @@ paths:
                     ccms_opponent_id: '381408'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Warrington and Halton Hospitals NHS Foundation Trust
+                    ccms_opponent_id: '381409'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: Warrington Borough Council
                     ccms_opponent_id: '281562'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
                   - name: Warrington PCT
                     ccms_opponent_id: '381416'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: Warrington and Halton Hospitals NHS Foundation Trust
-                    ccms_opponent_id: '381409'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: Warwick District Council
@@ -5454,6 +5454,10 @@ paths:
                     ccms_opponent_id: '381435'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: West Midlands and East NHS Trust
+                    ccms_opponent_id: '381436'
+                    ccms_type_text: National Health Service
+                    ccms_type_code: NHS
                   - name: West Midlands Government Office Region
                     ccms_opponent_id: '378919'
                     ccms_type_text: Government Department
@@ -5464,10 +5468,6 @@ paths:
                     ccms_type_code: POLICE
                   - name: West Midlands Strategic Health Authority
                     ccms_opponent_id: '381437'
-                    ccms_type_text: National Health Service
-                    ccms_type_code: NHS
-                  - name: West Midlands and East NHS Trust
-                    ccms_opponent_id: '381436'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: West Oxfordshire District Council
@@ -5483,11 +5483,11 @@ paths:
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
                   - name: West Sussex County Council
-                    ccms_opponent_id: '281402'
+                    ccms_opponent_id: '281628'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
                   - name: West Sussex County Council
-                    ccms_opponent_id: '281628'
+                    ccms_opponent_id: '281402'
                     ccms_type_text: Local Authority
                     ccms_type_code: LA
                   - name: West Sussex NHS Trust
@@ -5558,14 +5558,14 @@ paths:
                     ccms_opponent_id: '381575'
                     ccms_type_text: Police Authority
                     ccms_type_code: POLICE
-                  - name: Winchester City Council
-                    ccms_opponent_id: '281637'
-                    ccms_type_text: Local Authority
-                    ccms_type_code: LA
                   - name: Winchester and Eastleigh Healthcare NHS Trust
                     ccms_opponent_id: '381447'
                     ccms_type_text: National Health Service
                     ccms_type_code: NHS
+                  - name: Winchester City Council
+                    ccms_opponent_id: '281637'
+                    ccms_type_text: Local Authority
+                    ccms_type_code: LA
                   - name: Windsor and Maidenhead Royal Borough Council
                     ccms_opponent_id: '281639'
                     ccms_type_text: Local Authority
@@ -6062,7 +6062,6 @@ paths:
                       ccms_code: DA005
                       description: to be represented on an application for an occupation
                         order.
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       ccms_category_law: Family
@@ -6125,7 +6124,6 @@ paths:
                     description: to be represented on an application for an injunction,
                       order or declaration under the inherent jurisdiction of the
                       court.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6140,7 +6138,6 @@ paths:
                       an order under section 5 Protection from Harassment Act 1997
                       where the parties are associated persons (as defined by Part
                       IV Family Law Act 1996).
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6152,7 +6149,6 @@ paths:
                     meaning: Harassment - injunction
                     description: to be represented in an action for an injunction
                       under section 3 Protection from Harassment Act 1997.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6164,7 +6160,6 @@ paths:
                     meaning: Non-molestation order
                     description: to be represented on an application for a non-molestation
                       order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6176,7 +6171,6 @@ paths:
                     meaning: Occupation order
                     description: to be represented on an application for an occupation
                       order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6188,7 +6182,6 @@ paths:
                     meaning: Part IV - extend, vary or discharge
                     description: to be represented on an application to extend, vary
                       or discharge an order under Part IV Family Law Act 1996
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6200,7 +6193,6 @@ paths:
                     meaning: Forced marriage protection order
                     description: to be represented on an application for a forced
                       marriage protection order
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6213,7 +6205,6 @@ paths:
                     description: To be represented on an application for a Female
                       Genital Mutilation Protection Order under the Female Genital
                       Mutilation Act.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6225,7 +6216,6 @@ paths:
                     meaning: Prohibited steps order
                     description: to be represented on an application for a prohibited
                       steps order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6237,7 +6227,6 @@ paths:
                     meaning: Prohibited steps order - appeal
                     description: to be represented on an application for a prohibited
                       steps order.  Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6249,7 +6238,6 @@ paths:
                     meaning: Prohibited steps order - enforcement
                     description: to be represented on an application for a prohibited
                       steps order.  Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6261,7 +6249,6 @@ paths:
                     meaning: Specific issue order
                     description: to be represented on an application for a specific
                       issue order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6273,7 +6260,6 @@ paths:
                     meaning: Specific issue order - appeal
                     description: to be represented on an application for a specific
                       issue order.  Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6285,7 +6271,6 @@ paths:
                     meaning: Specific issue order - enforcement
                     description: to be represented on an application for a specific
                       issue order.  Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6297,7 +6282,6 @@ paths:
                     meaning: Prohibited steps order - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a prohibited steps order.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6309,7 +6293,6 @@ paths:
                     meaning: Prohibited steps order - appeal - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a prohibited steps order.  Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6321,7 +6304,6 @@ paths:
                     meaning: Prohibited steps order - enforcement - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a prohibited steps order.  Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6333,7 +6315,6 @@ paths:
                     meaning: Specific issue order - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a specific issue order.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6345,7 +6326,6 @@ paths:
                     meaning: Specific issue order - appeal - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a specific issue order.  Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6357,7 +6337,6 @@ paths:
                     meaning: Specific issue order - enforcement - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a specific issue order.  Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6369,7 +6348,6 @@ paths:
                     meaning: Child arrangements order (CAO) - contact
                     description: to be represented on an application for a child arrangements
                       order-who the child(ren) spend time with.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6381,7 +6359,6 @@ paths:
                     meaning: Child arrangements order (CAO) - contact - appeal
                     description: to be represented on an application for a child arrangements
                       order-who the child(ren) spend time with. Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6393,7 +6370,6 @@ paths:
                     meaning: Child arrangements order (CAO) - contact - enforcement
                     description: to be represented on an application for a child arrangements
                       order-who the child(ren) spend time with. Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6405,7 +6381,6 @@ paths:
                     meaning: Child arrangements order (CAO) - residence
                     description: to be represented on an application for a child arrangements
                       order –where the child(ren) will live
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6417,7 +6392,6 @@ paths:
                     meaning: Child arrangements order (CAO) - residence - appeal
                     description: to be represented on an application for a child arrangements
                       order –where the child(ren) will live. Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6429,7 +6403,6 @@ paths:
                     meaning: Child arrangements order (CAO) - residence - enforcement
                     description: to be represented on an application for a child arrangements
                       order –where the child(ren) will live. Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6441,7 +6414,6 @@ paths:
                     meaning: Child arrangements order (CAO) - contact - vary
                     description: to be represented on an application to vary/discharge
                       a child arrangements order-who the child(ren) spend time with.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6454,7 +6426,6 @@ paths:
                     description: to be represented on an application to vary/discharge
                       a child arrangements order-who the child(ren) spend time with.
                       Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6468,7 +6439,6 @@ paths:
                     description: to be represented on an application to vary/discharge
                       a child arrangements order-who the child(ren) spend time with.
                       Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6480,7 +6450,6 @@ paths:
                     meaning: Child arrangements order (CAO) - residence - vary
                     description: to be represented on an application to vary or discharge
                       a child arrangements order –where the child(ren) will live.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6494,7 +6463,6 @@ paths:
                     description: to be represented on an application to vary or discharge
                       a child arrangements order –where the child(ren) will live.
                       Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6508,7 +6476,6 @@ paths:
                     description: to be represented on an application to vary or discharge
                       a child arrangements order –where the child(ren) will live.
                       Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6520,7 +6487,6 @@ paths:
                     meaning: Enforcement order 11J
                     description: to be represented on an application for an enforcement
                       order under section 11J Children Act 1989.  Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6532,7 +6498,6 @@ paths:
                     meaning: Enforcement order 11J - appeal
                     description: to be represented on an application for an enforcement
                       order under section 11J Children Act 1989.  Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6545,7 +6510,6 @@ paths:
                     description: to be represented on an application for committal
                       and for an enforcement order under section 11J Children Act
                       1989. Enforcement only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6558,7 +6522,6 @@ paths:
                     description: to be represented on an application for the revocation
                       of an enforcement order under section 11J and Schedule A1 Children
                       Act 1989.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6571,7 +6534,6 @@ paths:
                     description: to be represented on an application for the revocation
                       of an enforcement order under section 11J and Schedule A1 Children
                       Act 1989.  Appeals only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6585,7 +6547,6 @@ paths:
                       for an amendment to an enforcement order or for a further enforcement
                       order under section 11J and Schedule A1 Children Act 1989.  Enforcement
                       only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6598,7 +6559,6 @@ paths:
                     description: to be represented on an application for compensation
                       for financial loss under section 11O Children Act 1989.  Appeals
                       only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6611,7 +6571,6 @@ paths:
                     description: to be represented on an application for compensation
                       for financial loss under section 11O Children Act 1989.  Enforcement
                       only.
-                    full_s8_only: true
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6623,7 +6582,6 @@ paths:
                     meaning: Child assessment order
                     description: to be represented on an application for a child assessment
                       order.
-                    full_s8_only: false
                     sca_core: true
                     sca_related: false
                     non_means_tested_plf: false
@@ -6635,7 +6593,6 @@ paths:
                     meaning: Emergency protection order - extend
                     description: to be represented on an application for or to extend
                       an emergency protection order.
-                    full_s8_only: false
                     sca_core: true
                     sca_related: false
                     non_means_tested_plf: false
@@ -6647,7 +6604,6 @@ paths:
                     meaning: Emergency protection order - discharge
                     description: to be represented on an application to discharge
                       an emergency protection order.
-                    full_s8_only: false
                     sca_core: true
                     sca_related: false
                     non_means_tested_plf: false
@@ -6659,7 +6615,6 @@ paths:
                     meaning: Secure accommodation order
                     description: to be represented on an application for a secure
                       accommodation order.
-                    full_s8_only: false
                     sca_core: true
                     sca_related: false
                     non_means_tested_plf: false
@@ -6671,7 +6626,6 @@ paths:
                     meaning: Emergency protection order
                     description: to be represented on an application for an emergency
                       protection order.
-                    full_s8_only: false
                     sca_core: true
                     sca_related: false
                     non_means_tested_plf: false
@@ -6682,7 +6636,6 @@ paths:
                   - ccms_code: PB057
                     meaning: Care order
                     description: to be represented on an application for a care order
-                    full_s8_only: false
                     sca_core: true
                     sca_related: false
                     non_means_tested_plf: false
@@ -6694,7 +6647,6 @@ paths:
                     meaning: Supervision order
                     description: to be represented on an application for a supervision
                       order
-                    full_s8_only: false
                     sca_core: true
                     sca_related: false
                     non_means_tested_plf: false
@@ -6706,7 +6658,6 @@ paths:
                     meaning: Contact with a child in care
                     description: to be represented on an application for contact with
                       a child in care.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6718,7 +6669,6 @@ paths:
                     meaning: Recovery of children order
                     description: to be represented on an application for the recovery
                       of a child(ren).
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6730,7 +6680,6 @@ paths:
                     meaning: End contact with a child in care
                     description: to be represented on an application to terminate
                       contact with a child/children in care.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6742,7 +6691,6 @@ paths:
                     meaning: Prohibited steps order
                     description: to be represented on an application for a prohibited
                       steps order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6754,7 +6702,6 @@ paths:
                     meaning: Specific issue order
                     description: to be represented on an application for a specific
                       issue order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6766,7 +6713,6 @@ paths:
                     meaning: Contact order - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a contact order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6778,7 +6724,6 @@ paths:
                     meaning: Residence - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a residence order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6790,7 +6735,6 @@ paths:
                     meaning: Prohibited steps order - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a prohibitive steps order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6802,7 +6746,6 @@ paths:
                     meaning: Specific issue order - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a specific issues order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6814,7 +6757,6 @@ paths:
                     meaning: Parental responsibility
                     description: to be represented on an application for parental
                       responsibility.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6826,7 +6768,6 @@ paths:
                     meaning: Child arrangements order (CAO) - contact
                     description: to be represented on an application for a child arrangements
                       order-who the child(ren) spend time with
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6838,7 +6779,6 @@ paths:
                     meaning: Child arrangements order (CAO) - residence
                     description: to be represented on an application for a child arrangements
                       order-where the child(ren) will live
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6850,7 +6790,6 @@ paths:
                     meaning: Placement order
                     description: to be represented on an application for a placement
                       order .
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6862,7 +6801,6 @@ paths:
                     meaning: Special guardianship order
                     description: to be represented on an application for a Special
                       Guardianship Order .
-                    full_s8_only: false
                     sca_core: false
                     sca_related: true
                     non_means_tested_plf: false
@@ -6874,7 +6812,6 @@ paths:
                     meaning: Declaration for overseas adoption
                     description: to be represented on an application for a declaration
                       as to an overseas adoption.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6886,7 +6823,6 @@ paths:
                     meaning: Declaration for overseas adoption - appeal
                     description: to be represented on an application for a declaration
                       as to an overseas adoption.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6898,7 +6834,6 @@ paths:
                     meaning: Adoption - not being held in family proceedings court
                     description: to be represented on an application for an adoption
                       order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6910,7 +6845,6 @@ paths:
                     meaning: Adoption order - appeal
                     description: to be represented on an application for an adoption
                       order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6922,7 +6856,6 @@ paths:
                     meaning: Adoption order - enforcement
                     description: to be represented on an application for an adoption
                       order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6934,7 +6867,6 @@ paths:
                     meaning: Secure accommodation order
                     description: to be represented on an application for a secure
                       accommodation order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6946,7 +6878,6 @@ paths:
                     meaning: Secure accommodation order - appeal
                     description: to be represented on an application for a secure
                       accommodation order. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6958,7 +6889,6 @@ paths:
                     meaning: Secure accommodation order - enforcement
                     description: to be represented on an application for a secure
                       accommodation order. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6970,7 +6900,6 @@ paths:
                     meaning: Contact with a child in care
                     description: to be represented on an application for contact with
                       a child in care.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6982,7 +6911,6 @@ paths:
                     meaning: Contact with a child in care - appeal
                     description: to be represented on an application for contact with
                       a child in care.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -6994,7 +6922,6 @@ paths:
                     meaning: Contact with a child in care - enforcement
                     description: to be represented on an application for contact with
                       a child in care.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7006,7 +6933,6 @@ paths:
                     meaning: Supervision order - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a supervision order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7018,7 +6944,6 @@ paths:
                     meaning: Supervision order - appeal - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a supervision order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7030,7 +6955,6 @@ paths:
                     meaning: Supervision order - enforcement - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a supervision order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7042,7 +6966,6 @@ paths:
                     meaning: Care order - discharge
                     description: to be represented on an application to discharge
                       a care order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7054,7 +6977,6 @@ paths:
                     meaning: Care order - appeal - discharge
                     description: to be represented on an application to discharge
                       a care order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7066,7 +6988,6 @@ paths:
                     meaning: Care order - enforcement - discharge
                     description: to be represented on an application to discharge
                       a care order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7078,7 +6999,6 @@ paths:
                     meaning: Education supervision order
                     description: to be represented on an application for an education
                       supervision order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7090,7 +7010,6 @@ paths:
                     meaning: Education supervision order - appeal
                     description: to be represented on an application for an education
                       supervision order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7102,7 +7021,6 @@ paths:
                     meaning: Education supervision order - enforcement
                     description: to be represented on an application for an education
                       supervision order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7114,7 +7032,6 @@ paths:
                     meaning: Recovery of children order
                     description: to be represented on an application for the recovery
                       of a child/children.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7126,7 +7043,6 @@ paths:
                     meaning: Recovery of children order - appeal
                     description: to be represented on an application for the recovery
                       of a child/children.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7138,7 +7054,6 @@ paths:
                     meaning: Recovery of children order - enforcement
                     description: to be represented on an application for the recovery
                       of a child/children.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7150,7 +7065,6 @@ paths:
                     meaning: Child assessment order - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a child assessment order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7162,7 +7076,6 @@ paths:
                     meaning: Child assessment order - appeal - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a child assessment order. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7174,7 +7087,6 @@ paths:
                     meaning: End contact with a child in care
                     description: to be represented on an application to terminate
                       contact with a child/children in care.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7186,7 +7098,6 @@ paths:
                     meaning: End contact with a child in care - appeal
                     description: to be represented on an application to terminate
                       contact with a child/children in care.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7198,7 +7109,6 @@ paths:
                     meaning: End contact with a child in care - enforcement
                     description: to be represented on an application to terminate
                       contact with a child/children in care.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7211,7 +7121,6 @@ paths:
                     description: to be represented on an application to substitute
                       a supervision order with care order under section 39 (4) Children
                       Act 1989.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7224,7 +7133,6 @@ paths:
                     description: to be represented on an application to substitute
                       a supervision order with care order under section 39 (4) Children
                       Act 1989. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7236,7 +7144,6 @@ paths:
                     meaning: Prohibited steps order
                     description: to be represented on an application for a prohibited
                       steps order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7248,7 +7155,6 @@ paths:
                     meaning: Prohibited steps order - appeal
                     description: to be represented on an application for a prohibited
                       steps order. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7260,7 +7166,6 @@ paths:
                     meaning: Prohibited steps order - enforcement
                     description: to be represented on an application for a prohibited
                       steps order. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7272,7 +7177,6 @@ paths:
                     meaning: Specific issue order
                     description: to be represented on an application for a specific
                       issue order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7284,7 +7188,6 @@ paths:
                     meaning: Specific issue order - appeal
                     description: to be represented on an application for a specific
                       issue order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7296,7 +7199,6 @@ paths:
                     meaning: Specific issue order - enforcement
                     description: to be represented on an application for a specific
                       issue order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7308,7 +7210,6 @@ paths:
                     meaning: Child arrangements order (CAO) - contact - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a contact order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7321,7 +7222,6 @@ paths:
                       or discharge
                     description: to be represented on an application to vary or discharge
                       a contact order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7334,7 +7234,6 @@ paths:
                       - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a contact order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7347,7 +7246,6 @@ paths:
                       discharge
                     description: to be represented on an application to vary or discharge
                       a residence order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7360,7 +7258,6 @@ paths:
                       vary or discharge
                     description: to be represented on an application to vary or discharge
                       a residence order. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7373,7 +7270,6 @@ paths:
                       - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a residence order. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7385,7 +7281,6 @@ paths:
                     meaning: Prohibited steps order - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a prohibited steps order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7397,7 +7292,6 @@ paths:
                     meaning: Prohibited steps order - appeal - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a prohibited steps order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7409,7 +7303,6 @@ paths:
                     meaning: Prohibited steps order - enforcement - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a prohibited steps order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7421,7 +7314,6 @@ paths:
                     meaning: Specific issue order - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a specific issue order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7433,7 +7325,6 @@ paths:
                     meaning: Specific issue order - appeal - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a specific issue order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7445,7 +7336,6 @@ paths:
                     meaning: Specific issue order - enforcement - vary or discharge
                     description: to be represented on an application to vary or discharge
                       a specific issue order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7457,7 +7347,6 @@ paths:
                     meaning: Parental responsibility
                     description: to be represented on an application for parental
                       responsibility.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7469,7 +7358,6 @@ paths:
                     meaning: Parental responsibility - appeal
                     description: to be represented on an application for parental
                       responsibility.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7480,7 +7368,6 @@ paths:
                   - ccms_code: PBM23
                     meaning: Care order
                     description: to be represented on an application for a care order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7492,7 +7379,6 @@ paths:
                     meaning: Care order - appeal
                     description: to be represented on an application for a care order.
                       Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7504,7 +7390,6 @@ paths:
                     meaning: Care order - enforcement
                     description: to be represented on an application for a care order.
                       Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7516,7 +7401,6 @@ paths:
                     meaning: Supervision order
                     description: to be represented on an application for a supervision
                       order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7528,7 +7412,6 @@ paths:
                     meaning: Supervision order - appeal
                     description: to be represented on an application for a supervision
                       order. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7540,7 +7423,6 @@ paths:
                     meaning: Supervision order - enforcement
                     description: to be represented on an application for a supervision
                       order. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7552,7 +7434,6 @@ paths:
                     meaning: Child assessment order
                     description: to be represented on an application for a child assessment
                       order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7564,7 +7445,6 @@ paths:
                     meaning: Child assessment order - appeal
                     description: to be represented on an application for a child assessment
                       order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7576,7 +7456,6 @@ paths:
                     meaning: Child assessment order - enforcement
                     description: to be represented on an application for a child assessment
                       order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7588,7 +7467,6 @@ paths:
                     meaning: Emergency protection order
                     description: to be represented on an application for or to extend
                       an emergency protection order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7600,7 +7478,6 @@ paths:
                     meaning: Emergency protection order - appeal
                     description: to be represented on an application for or to extend
                       an emergency protection order. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7612,7 +7489,6 @@ paths:
                     meaning: Emergency protection order - enforcement
                     description: to be represented on an application for or to extend
                       an emergency protection order. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7624,7 +7500,6 @@ paths:
                     meaning: Emergency protection order - discharge
                     description: to be represented on an application to discharge
                       an emergency protection order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7636,7 +7511,6 @@ paths:
                     meaning: Emergency protection order - appeal - discharge
                     description: to be represented on an application to discharge
                       an emergency protection order. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7648,7 +7522,6 @@ paths:
                     meaning: Exclusion requirement
                     description: to be represented on an application to vary/discharge
                       an exclusion requirement.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7660,7 +7533,6 @@ paths:
                     meaning: Exclusion requirement - appeal
                     description: to be represented on an application to vary/discharge
                       an exclusion requirement.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7672,7 +7544,6 @@ paths:
                     meaning: Exclusion requirement - enforcement
                     description: to be represented on an application to vary/discharge
                       an exclusion requirement.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7684,7 +7555,6 @@ paths:
                     meaning: Placement order
                     description: to be represented on an application for a placement
                       order
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7696,7 +7566,6 @@ paths:
                     meaning: Placement order - appeal
                     description: to be represented on an application for a placement
                       order. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7708,7 +7577,6 @@ paths:
                     meaning: Placement order - enforcement
                     description: to be represented on an application for a placement
                       order. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7720,7 +7588,6 @@ paths:
                     meaning: Special guardianship order
                     description: to be represented on an application for a Special
                       Guardianship Order
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7732,7 +7599,6 @@ paths:
                     meaning: Special guardianship order - appeal
                     description: to be represented on an application for a Special
                       Guardianship Order . Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7744,7 +7610,6 @@ paths:
                     meaning: Special guardianship order - enforcement
                     description: to be represented on an application for a Special
                       Guardianship Order . Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7756,7 +7621,6 @@ paths:
                     meaning: Revocation placement order
                     description: to be represented on an application for revocation
                       of a placement order
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7768,7 +7632,6 @@ paths:
                     meaning: Revocation placement order - appeal
                     description: to be represented on an application for revocation
                       of a placement order  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7780,7 +7643,6 @@ paths:
                     meaning: Revocation placement order - enforcement
                     description: to be represented on an application for revocation
                       of a placement order  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7792,7 +7654,6 @@ paths:
                     meaning: Special guardianship order - vary or discharge
                     description: To be represented on an application for variation/discharge
                       of a special guardianship order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7804,7 +7665,6 @@ paths:
                     meaning: Special guardianship order - appeal - vary or discharge
                     description: To be represented on an application for variation/discharge
                       of a special guardianship order.  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7816,7 +7676,6 @@ paths:
                     meaning: Special guardianship order - enforcement - vary or discharge
                     description: To be represented on an application for variation/discharge
                       of a special guardianship order.  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7827,7 +7686,6 @@ paths:
                   - ccms_code: PBM36
                     meaning: Care order - joined party
                     description: to be represented on an application for a care order
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7839,7 +7697,6 @@ paths:
                     meaning: Care order - joined party - appeal
                     description: to be represented on an application for a care order
                       Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7851,7 +7708,6 @@ paths:
                     meaning: Care order - joined party - enforcement
                     description: to be represented on an application for a care order
                       Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7863,7 +7719,6 @@ paths:
                     meaning: Supervision order - joined party
                     description: to be represented on an application for a supervision
                       order
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7875,7 +7730,6 @@ paths:
                     meaning: Supervision order - joined party - appeal
                     description: to be represented on an application for a supervision
                       order  Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7887,7 +7741,6 @@ paths:
                     meaning: Supervision order - joined party - enforcement
                     description: to be represented on an application for a supervision
                       order  Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7899,7 +7752,6 @@ paths:
                     meaning: Child arrangements order (CAO) - contact
                     description: to be represented on an application for a child arrangements
                       order - who the child(ren) spend time with
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7911,7 +7763,6 @@ paths:
                     meaning: Child arrangements order (CAO) - contact - appeal
                     description: to be represented on an application for a child arrangements
                       order - who the child(ren) spend time with. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7923,7 +7774,6 @@ paths:
                     meaning: Child arrangements order (CAO) - contact - enforcement
                     description: to be represented on an application for a child arrangements
                       order - who the child(ren) spend time with. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7935,7 +7785,6 @@ paths:
                     meaning: Child arrangements order (CAO) - residence
                     description: to be represented on an application for a child arrangements
                       order - where the child(ren) will live.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7947,7 +7796,6 @@ paths:
                     meaning: Child arrangements order (CAO) - residence - appeal
                     description: to be represented on an application for a child arrangements
                       order - where the child(ren) will live. Appeals only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7959,7 +7807,6 @@ paths:
                     meaning: Child arrangements order (CAO) - residence - enforcement
                     description: to be represented on an application for a child arrangements
                       order - where the child(ren) will live. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: false
@@ -7971,7 +7818,6 @@ paths:
                     meaning: Placement order - parent or parental responsibility
                     description: To represent a parent or person with parental responsibility
                       on an application for a placement order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: true
@@ -7984,7 +7830,6 @@ paths:
                       enforcement
                     description: To represent a parent or person with parental responsibility
                       on an application for a placement order. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: true
@@ -7996,7 +7841,6 @@ paths:
                     meaning: Adoption order - parent or parental responsibility
                     description: To represent a parent or person with parental responsibility
                       on an application for an adoption order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: true
@@ -8009,7 +7853,6 @@ paths:
                       enforcement
                     description: To represent a parent or person with parental responsibility
                       on an application for a placement order. Enforcement only.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     non_means_tested_plf: true
@@ -8044,7 +7887,6 @@ paths:
                       ccms_code: DA005
                       description: to be represented on an application for an occupation
                         order.
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       non_means_tested_plf: false
@@ -8070,7 +7912,6 @@ paths:
                       description: to be represented on an application for an injunction,
                         order or declaration under the inherent jurisdiction of the
                         court.
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       non_means_tested_plf: false
@@ -8081,7 +7922,6 @@ paths:
                       ccms_code: DA003
                       description: to be represented in an action for an injunction
                         under section 3 Protection from Harassment Act 1997.
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       non_means_tested_plf: false
@@ -8092,7 +7932,6 @@ paths:
                       ccms_code: DA004
                       description: to be represented on an application for a non-molestation
                         order.
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       non_means_tested_plf: false
@@ -8165,7 +8004,6 @@ paths:
                     success: true
                     proceeding_types:
                     - ccms_code: DA005
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       gross_income_upper: true
@@ -8173,7 +8011,6 @@ paths:
                       capital_upper: true
                       matter_type: domestic abuse (DA)
                     - ccms_code: SE004
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       gross_income_upper: false
@@ -8181,7 +8018,6 @@ paths:
                       capital_upper: false
                       matter_type: section 8 children (S8)
                     - ccms_code: SE013
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       gross_income_upper: false
@@ -8259,7 +8095,6 @@ paths:
                     name: prohibited_steps_order_s8
                     description: to be represented on an application for a prohibited
                       steps order.
-                    full_s8_only: false
                     sca_core: false
                     sca_related: false
                     ccms_category_law: Family
@@ -8336,7 +8171,6 @@ paths:
                     success: true
                     proceedings:
                     - ccms_code: DA005
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       client_involvement_type: A
@@ -8345,7 +8179,6 @@ paths:
                       capital_upper: true
                       matter_type: domestic abuse (DA)
                     - ccms_code: SE004
-                      full_s8_only: false
                       sca_core: false
                       sca_related: false
                       client_involvement_type: D


### PR DESCRIPTION
## What

The swagger docs were re-generated after removal of full_s8_only, but the commit seems to have been omitted from the pull request.

The actual end point no longer returns the value but the examples all still included the field.

This PR re-regenerates the swagger docs using `NOCOVERAGE=true rake rswag`

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
