### PR TITLE
Chore: Remove CodeClimate from repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,8 +75,7 @@ references:
     run:
       name: Database Setup
       command: |
-        bundle exec rake db:create db:schema:load
-        bundle exec rake db:migrate
+        bundle exec rails db:prepare
 
 commands:
   build-and-push-to-ecr:
@@ -126,17 +125,9 @@ jobs:
       - *save_gems_cache
       - *setup_database
       - run:
-          name: Setup Code Climate test-reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./tmp/cc-test-reporter
-            chmod +x ./tmp/cc-test-reporter
-      - run:
           name: Run ruby tests
           command: |
-            ./tmp/cc-test-reporter before-build
             bundle exec rspec --format progress --format RspecJunitFormatter -o /tmp/test-results/rspec/rspec.xml
-            ./tmp/cc-test-reporter format-coverage -t simplecov -o tmp/coverage/codeclimate.json
-            ./tmp/cc-test-reporter upload-coverage -i tmp/coverage/codeclimate.json
       - store_test_results:
           path: /tmp/test-results/rspec
       - store_artifacts:


### PR DESCRIPTION

## What

The CodeClimate quality checks were deprecated over the weekend, this PR removes the circle ci uploads

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
