### PR TITLE
Chore: Remove deprecated platforms tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ gem "sentry-ruby"
 group :development, :test do
   gem "awesome_print"
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem "byebug", platforms: %i[mri mingw x64_mingw]
+  gem "byebug"
   gem "factory_bot_rails", ">= 6.2.0"
   gem "faker", ">=1.9.1"
   gem "json_expressions"


### PR DESCRIPTION
## What
Remove deprecated platforms tags

Handles this deprecation notice
```
[DEPRECATED] Platform :mingw, :x64_mingw is deprecated. Please use platform :windows instead.
```

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
