### PR TITLE
AP-6214: Amend postgresql chart's image repository as part of helm upgrade

### DIFF
--- a/bin/uat_deploy
+++ b/bin/uat_deploy
@@ -8,10 +8,13 @@ deploy() {
 
   echo "Deploying CIRCLE_SHA1: $CIRCLE_SHA1 under release name: '$RELEASE_NAME'..."
 
+  # Temporary solution:  amend postgres chart's to use bitnamilegacy for its image repository. See https://github.com/bitnami/charts/issues/35164 for details
   helm upgrade $RELEASE_NAME ./deploy/helm/. \
                 --install --wait \
                 --namespace=${K8S_NAMESPACE} \
                 --values ./deploy/helm/values-uat.yaml \
+                --set postgresql.image.repository=bitnamilegacy/postgresql \
+                --set postgresql.global.security.allowInsecureImages=true \
                 --set deploy.host="$RELEASE_HOST" \
                 --set image.repository="$IMG_REPO" \
                 --set image.tag="$CIRCLE_SHA1" \


### PR DESCRIPTION
## What
Use legacy images

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6214)

Bitnami moving to paid tier or unpaid latest images only

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
