### PR TITLE
AP-6818: Reduce docker image scan permissions

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -2,6 +2,7 @@ name: Scan docker image
 on:
   schedule:
     - cron: '0 5 * * *'
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -9,7 +9,6 @@ jobs:
   scan-docker-image:
     uses: ministryofjustice/laa-reusable-github-actions/.github/workflows/snyk.yml@7c81d37978aef9418f7185d9ecf70e3cd1c63c02 # main on 15/04/2026
     permissions:
-      contents: read # for actions/checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
     with:
       tag: "legal-framework-application"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/AP-6818)

- Reduce docker image scan permissions
- Add workflow dispatch to allow testing without having to wait for cron job

## Checklist

Before you ask people to review this PR:

- Tests and rubocop should be passing: `bundle exec rake`.
- Github should not be reporting conflicts; you should have recently run `git rebase main`.
- The standards in the [Git Workflow document on Confluence](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/4602855954/Git+Workflow) should be followed.
- There should be no unnecessary whitespace changes. These make diffs harder to read and conflicts more likely.
- The PR description should say what you changed and why, with a link to the JIRA story.
- You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- You should have checked that the commit messages say why the change was made.
